### PR TITLE
Mongo & Create Application Testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
       run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
 
     - name: Run tests
-      run: pytest -v
+      run: pytest -v -m "not integration"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers=
+    integration: marks tests as integration tests (deselect with '-m "not integration"')

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ websockets==14.1
 pymongo==4.10.1
 pytest==8.3.4
 pytest-cov==4.1.0
+mongomock==4.3.0

--- a/src/app/models/mongo/schemas.py
+++ b/src/app/models/mongo/schemas.py
@@ -46,18 +46,27 @@ collections: dict[str, CollectionProps] = {
     )
 }
 
-def init_schemas(mongo: Database):
+def init_collections(mongo: Database, with_validators=True):
+    """
+    Initializes collections and their indexes.
+    Will be deprecated and replaced with Mongo migrations.
+    """
     existing_collections = set(mongo.list_collection_names())
 
     # if the collection exists, update with db.command; else create the collection
     for collection_name, collection_props in collections.items():
         if collection_name not in existing_collections:
             # create the schema with the above defined JSON schema
-            mongo.create_collection(
-                collection_name,
-                validator={"$jsonSchema": collection_props.schema},
-                validationLevel="moderate" # validates on writes
-            )
+            
+            if with_validators:
+                mongo.create_collection(
+                    collection_name,
+                    validator={"$jsonSchema": collection_props.schema},
+                    validationLevel="moderate" # validates on writes
+                )
+            else:
+                mongo.create_collection(collection_name)
+
             # if the collection requires indexes, include them upon creation
             if len(collection_props.indexes) > 0:
                 mongo.get_collection(collection_name).create_indexes(collection_props.indexes)

--- a/src/app/models/mongo/schemas.py
+++ b/src/app/models/mongo/schemas.py
@@ -47,17 +47,13 @@ collections: dict[str, CollectionProps] = {
 }
 
 def init_collections(mongo: Database, with_validators=True):
-    """
-    Initializes collections and their indexes.
-    Will be deprecated and replaced with Mongo migrations.
-    """
+    """Initializes collections and their indexes"""
     existing_collections = set(mongo.list_collection_names())
 
     # if the collection exists, update with db.command; else create the collection
     for collection_name, collection_props in collections.items():
         if collection_name not in existing_collections:
-            # create the schema with the above defined JSON schema
-            
+            # create the schema with the above defined JSON schema given with_validators option
             if with_validators:
                 mongo.create_collection(
                     collection_name,

--- a/src/db_scripts/mongo.py
+++ b/src/db_scripts/mongo.py
@@ -13,13 +13,10 @@ if not MONGO_URL:
 
 # Create a new client and connect to the server
 client = MongoClient(MONGO_URL, server_api=ServerApi('1'))
+
 # Send a ping to confirm a successful connection
 def ping_mongo(client: MongoClient):
-    try:
-        client.admin.command('ping')
-        print("Pinged your deployment. You successfully connected to MongoDB!")
-    except Exception as e:
-        print(e)
+	client.admin.command('ping')
 
 def get_mongo():
     return client[MONGO_DATABASE_NAME]

--- a/src/db_scripts/mongo.py
+++ b/src/db_scripts/mongo.py
@@ -4,7 +4,7 @@ from pymongo.mongo_client import MongoClient
 from pymongo.server_api import ServerApi
 from bson import json_util
 
-from src.app.models.mongo.schemas import init_schemas
+from src.app.models.mongo.schemas import init_collections
 from src.config import MONGO_DATABASE_NAME
 
 MONGO_URL = environ.get("CTI_MONGO_URL")
@@ -25,7 +25,7 @@ def get_mongo():
     return client[MONGO_DATABASE_NAME]
 
 def init_mongo():
-    init_schemas(get_mongo())
+    init_collections(get_mongo())
 
 async def close_mongo():
     return client.close()

--- a/src/main.py
+++ b/src/main.py
@@ -52,7 +52,8 @@ def database_test(db: Session = Depends(make_session)):
 @app.get("/test-mongo")
 def mongo_test(db: Database = Depends(get_mongo)):
     try:
-        return ping_mongo(db.client)
+        ping_mongo(db.client)
+        return {"message": "Successfully accessed MongoDB"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error accessing MongoDB: {str(e)}")
     

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,10 @@
+import bson
 import pytest
+import mongomock
 from fastapi.testclient import TestClient
+from src.app.models.mongo.schemas import init_collections
+from src.config import MONGO_DATABASE_NAME
+from src.db_scripts.mongo import get_mongo
 from src.main import app
 
 client = TestClient(app)
@@ -13,3 +18,45 @@ def test_confirm_conn():
     response = client.get("/test-connection")
     assert response.status_code == 200
     assert response.json() == {"message": "Database connection succeeded"}
+
+@pytest.fixture(scope="function")
+def mock_mongo():
+    """Creates a fresh mock database and overrides FastAPI dependency."""
+    mock_client = mongomock.MongoClient()
+    db = mock_client[MONGO_DATABASE_NAME]
+
+    # Apply indexes (json schema validators cannot be enforced in mongomock)
+    init_collections(db, with_validators=False)
+
+    # Override FastAPI's database dependency
+    app.dependency_overrides[get_mongo] = lambda: db
+
+    yield db # Provide the mock DB instance
+
+    app.dependency_overrides.pop(get_mongo) # Clean up override(s) after test
+    mock_client.close()
+
+class TestCreateApplication:
+    def test_min_required_success(self, mock_mongo):
+        response = client.post("/api/applications", json={
+            "fname": "First",
+            "lname": "Last",
+            "email": "test.user@cti.com"
+        })
+
+        assert response.status_code == 201
+        assert bson.ObjectId.is_valid(response.json()["_id"])
+
+    def test_extras_success(self, mock_mongo):
+        response = client.post("/api/applications", json={
+            "fname": "First",
+            "lname": "Last",
+            "email": "test.user@cti.com",
+            "cohort": True,
+            "graduating_year": 2024
+        })
+
+        assert response.status_code == 201
+        assert bson.ObjectId.is_valid(response.json()["_id"])
+        assert response.json()["cohort"]
+        assert response.json()["graduating_year"] == 2024

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,6 +114,7 @@ class TestCreateApplication:
         assert "not a valid email address" in detail["msg"]
 
     def test_failure_duplicate_email_key(self, mock_mongo_db: mongomock.Database):
+        # pydantic model used to validate test data before inserting as mongomock does not support json schema validation
         app = ApplicationModel(
             fname="First",
             lname="Last",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -60,3 +60,53 @@ class TestCreateApplication:
         assert bson.ObjectId.is_valid(response.json()["_id"])
         assert response.json()["cohort"]
         assert response.json()["graduating_year"] == 2024
+
+    def test_missing_required_field(self, mock_mongo):
+        response = client.post("/api/applications", json={
+            "fname": "First",
+            # missing lname
+            "email": "test.user@cti.com",
+            "cohort": True,
+            "graduating_year": 2024
+        })
+
+        assert response.status_code == 422
+        detail_item = response.json()["detail"][0]
+        assert detail_item["type"] == "missing"
+
+    def test_invalid_email(self, mock_mongo):
+        response = client.post("/api/applications", json={
+            "fname": "First",
+            "lname": "Last",
+            "email": "test.user@cti",
+            "cohort": True,
+            "graduating_year": 2024
+        })
+
+        assert response.status_code == 422
+        detail_item = response.json()["detail"][0]
+        assert detail_item["type"] == "value_error"
+        assert str(detail_item["msg"]).find("not a valid email address")
+
+    def test_duplicate_key(self, mock_mongo):
+        # 409
+        assert True
+
+    @pytest.mark.integration
+    def test_persistence_success(self):
+        """Integration test validating the persistence of application inserts"""
+        assert True
+    
+    @pytest.mark.integration
+    def test_schema_valid_insert_success(self):
+        """Integration test validating that a document can be inserted
+        if the fields follow the collection json validation schema
+        """
+        assert True
+        
+    @pytest.mark.integration
+    def test_schema_invalid_insert(self):
+        """Integration test validating that a document will not be inserted
+        if it does not follow the collection json validation schema
+        """
+        assert True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,15 @@
-from typing import Generator
+from datetime import datetime, timezone
+import os
 import bson
+import pymongo
+import pymongo.client_session
+import pymongo.database
+import pymongo.errors
+import pymongo.mongo_client
 import pytest
 import mongomock
 from fastapi.testclient import TestClient
+from src.app.models.mongo.models import ApplicationModel
 from src.app.models.mongo.schemas import init_collections
 from src.config import APPLICATIONS_COLLECTION, MONGO_DATABASE_NAME
 from src.db_scripts.mongo import get_mongo
@@ -22,7 +29,7 @@ def test_confirm_conn():
 
 @pytest.fixture(scope="function")
 def mock_mongo():
-    """Creates a fresh mock database and overrides FastAPI dependency."""
+    """Injection for MongoDB dependency intended for fast, in-memory unit testing"""
     mock_client = mongomock.MongoClient()
     db = mock_client[MONGO_DATABASE_NAME]
 
@@ -36,6 +43,23 @@ def mock_mongo():
 
     app.dependency_overrides.pop(get_mongo) # Clean up override(s) after test
     mock_client.close()
+
+@pytest.fixture(scope="function")
+def test_mongo():
+    """Injection for MongoDB dependency intended for wide scope, accurate integration testing"""
+    # Consider replacing this with a conditionally created local instance (in GitHub Actions)
+    client = pymongo.MongoClient(os.environ.get("CTI_MONGO_URL"))
+    test_db_name = "test_" + MONGO_DATABASE_NAME
+    db = client[test_db_name]
+    init_collections(db, with_validators=True)
+
+    app.dependency_overrides[get_mongo] = lambda: db
+
+    yield db
+
+    app.dependency_overrides.pop(get_mongo)
+    client.drop_database(db)
+    client.close()
 
 class TestCreateApplication:
     def test_min_required_success(self, mock_mongo: mongomock.Database):
@@ -87,16 +111,19 @@ class TestCreateApplication:
         assert response.status_code == 422
         detail = response.json()["detail"][0]
         assert detail["type"] == "value_error"
-        assert str(detail["msg"]).find("not a valid email address") != -1
+        assert "not a valid email address" in detail["msg"]
 
     def test_duplicate_key(self, mock_mongo: mongomock.Database):
-        mock_mongo.get_collection(APPLICATIONS_COLLECTION).insert_one({
-            "fname": "First",
-            "lname": "Last",
-            "email": "test.user@cti.com", # email is a unique index
-            "cohort": True,
-            "graduating_year": 2024
-        })
+        app = ApplicationModel(
+            fname="First",
+            lname="Last",
+            email="test.user@cti.com", # email is a unique index
+            cohort=True,
+            graduating_year=2024,
+            app_submitted=datetime.now(timezone.utc)
+        )
+        
+        mock_mongo.get_collection(APPLICATIONS_COLLECTION).insert_one(app.model_dump())
         
         response = client.post("/api/applications", json={
             "fname": "First",
@@ -108,23 +135,43 @@ class TestCreateApplication:
 
         assert response.status_code == 409
         detail = response.json()["detail"]
-        assert str(detail).find("Duplicate index key") != -1
+        assert "Duplicate index key" in detail
 
     @pytest.mark.integration
-    def test_persistence_success(self):
-        """Integration test validating the persistence of application inserts"""
-        assert True
+    def test_persistence_success(self, test_mongo: pymongo.database.Database):
+        """Integration test validating that a document can be inserted and found
+        if the fields follow the collection schema
+        """
+        app_collection = test_mongo.get_collection(APPLICATIONS_COLLECTION)
+
+        prev_count = app_collection.count_documents({})
+
+        response = client.post("/api/applications", json={
+            "fname": "First",
+            "lname": "Last",
+            "email": "test.user@cti.com"
+        })
+
+        inserted = app_collection.find_one({"email": "test.user@cti.com"})
+
+        assert response.status_code == 201
+        assert bson.ObjectId.is_valid(response.json()["_id"])
+        assert inserted is not None and str(inserted["_id"]) == response.json()["_id"]
+        assert prev_count + 1 == app_collection.count_documents({})
     
     @pytest.mark.integration
-    def test_schema_valid_insert_success(self):
-        """Integration test validating that a document can be inserted
-        if the fields follow the collection json validation schema
-        """
-        assert True
-        
-    @pytest.mark.integration
-    def test_schema_invalid_insert(self):
+    def test_schema_rejects_invalid_insert(self, test_mongo: pymongo.database.Database):
         """Integration test validating that a document will not be inserted
-        if it does not follow the collection json validation schema
+        if it does not follow the collection json validation schema.
+        
+        Relevant for inserts performed outside of API.
         """
-        assert True
+        app_collection = test_mongo.get_collection(APPLICATIONS_COLLECTION)
+
+        with pytest.raises(pymongo.errors.WriteError, match="Document failed validation"):
+            app_collection.insert_one({
+                "fname": "First",
+                "lname": "Last",
+                "email": "test.user@cti.com"
+                # missing app_submitted
+            })


### PR DESCRIPTION
## Mongo & Create Application Testing
Added with this change are the unit and integration tests for the `POST /api/applications` endpoint as well as the testing dependencies and pytest fixtures to be used for MongoDB. Small changes made to both `GET /test-mongo` endpoint for making it testable as well as the `init_collections` function to optionally allow schema-less collection initialization.

### Issues Fixed
* No direct issue

### Tests
Pull request adds 2 success unit tests, 3 failure unit tests, and 2 integration tests under the `TestCreateApplication` pytest class. To run all of these new tests locally, execute the following:

```bash
$ pytest -v -k "TestCreateApplication"
```

Coverage information with the addition of these tests:

```bash
$ pytest --cov=src -v
...
---------- coverage: platform linux, python 3.10.12-final-0 ----------
Name                                   Stmts   Miss  Cover
----------------------------------------------------------
src/__init__.py                            0      0   100%
src/app/__init__.py                        0      0   100%
src/app/database.py                       17      1    94%
src/app/models/mongo/__init__.py           0      0   100%
src/app/models/mongo/models.py            14      0   100%
src/app/models/mongo/schemas.py           19      1    95%
src/app/models/postgres/__init__.py        0      0   100%
src/app/models/postgres/models.py        102      0   100%
src/app/models/postgres/schemas.py        17      0   100%
src/config.py                              2      0   100%
src/db_scripts/__init__.py                 0      0   100%
src/db_scripts/create_database.py          4      4     0%
src/db_scripts/mongo.py                   21      6    71%
src/db_scripts/sqlalchemy_testing.py      34     34     0%
src/main.py                               64     19    70%
----------------------------------------------------------
TOTAL                                    294     65    78%
```

### Note on GitHub Actions:
Concerning GitHub Actions testing, current implementation requirements dictate that integration tests (marked with `@pytest.mark.integration` will **not** be run on each commit to a remote branch. All other tests **will** be run automatically and reported per commit to the repository. This is done through the following exectution found in `.github/workflows/test.yml`:

```bash
$ pytest -v -m "not integration"
```

The above can also be run to execute all non-integration tests in local development.

### Checklist
- [x] I've reviewed the contribution guide
- [x] I've confirmed the changes work on my machine
- [x] This pull request is ready for review