### PR TITLE
Alternate email address processing [TASK] #12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ MarkupSafe==3.0.2
 mdurl==0.1.2
 packaging==24.2
 psycopg==3.2.3
-psycopg-binary==3.2.3
+psycopg-binary==3.2.4
 psycopg-pool==3.2.4
 pydantic==2.10.4
 pydantic_core==2.27.2

--- a/src/app/models/postgres/models.py
+++ b/src/app/models/postgres/models.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from datetime import datetime, date
 from typing import List, Optional
 from ...database import Base
+from pydantic import BaseModel, EmailStr
+
 
 # TODO: Determine which back_populates are needed WIP
 # TODO: Get test data set-up, maybe a larger set WIP
@@ -149,3 +151,17 @@ class AccountabilityGroup(Base):
     group_name: Mapped[str] = mapped_column(String)
     student_accelerator: Mapped[str] = mapped_column(String)
     ag_students: Mapped[List["Accelerate"]] = relationship(back_populates="ag_record")
+
+
+##################################
+# Request models
+##################################
+
+# Alternate email request model
+class AlternateEmailRequest(BaseModel):
+    fname: str
+    lname: str
+    alt_emails: List[EmailStr] = []
+    primary_email: Optional[str] = None
+    remove_emails: List[EmailStr] = []
+    google_form_email: EmailStr

--- a/src/app/models/postgres/models.py
+++ b/src/app/models/postgres/models.py
@@ -159,8 +159,6 @@ class AccountabilityGroup(Base):
 
 # Alternate email request model
 class AlternateEmailRequest(BaseModel):
-    fname: str
-    lname: str
     alt_emails: List[EmailStr] = []
     primary_email: Optional[str] = None
     remove_emails: List[EmailStr] = []

--- a/src/app/models/postgres/schemas.py
+++ b/src/app/models/postgres/schemas.py
@@ -1,19 +1,27 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, EmailStr
+from typing import List, Optional
+from datetime import datetime, date
+
 
 class ORMSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
+class StudentEmailSchema(ORMSchema):
+    email: EmailStr
+    is_primary: bool
+
 class StudentSchema(ORMSchema):
     cti_id: int
     fname: str
-    pname: str
+    pname: Optional[str] = None
     lname: str
-    join_date: str # TODO Validate date
+    join_date: datetime
     target_year: int
-    gender: str
-    first_gen: bool
-    institution: str
-    is_graduate: bool
-    birthday: str # TODO Validate date
+    gender: Optional[str] = None
+    first_gen: Optional[bool] = None
+    institution: Optional[str] = None
+    is_graduate: Optional[bool] = False
+    birthday: Optional[date] = None
     active: bool
     cohort_lc: bool
+    email_addresses: List[StudentEmailSchema]

--- a/src/main.py
+++ b/src/main.py
@@ -6,13 +6,14 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import text
 from pymongo.database import Database
+from sqlalchemy import func
 
 from src.app.models.mongo.models import ApplicationCreate, ApplicationModel
 from src.config import APPLICATIONS_COLLECTION
 from src.db_scripts.mongo import close_mongo, get_mongo, init_mongo , ping_mongo
 
 from .app.database import make_session
-from .app.models.postgres.models import Student
+from .app.models.postgres.models import Student, StudentEmail, AlternateEmailRequest
 from .app.models.postgres.schemas import StudentSchema
 
 @asynccontextmanager
@@ -44,6 +45,7 @@ def database_test(db: Session = Depends(make_session)):
         exists = db.query(Student).first()
         if exists:
             return StudentSchema.model_validate(Student)
+            # return StudentSchema.model_validate(exists)
         else:
             return {"message": "Database Accessible, but contains no data"}
     except SQLAlchemyError:
@@ -105,3 +107,91 @@ def create_application(
         raise HTTPException(status_code=409, detail=f"Duplicate index key value received: {str(e)}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"{str(e)}")
+
+@app.post("/api/students/alternate-emails", status_code=status.HTTP_200_OK)
+def modify_alternate_emails(
+    request: AlternateEmailRequest,
+    db: Session = Depends(make_session),
+):
+    try:
+        # Normalize all emails to lowercase
+        google_form_email = request.google_form_email.strip().lower()
+        request_primary_email = request.primary_email.strip().lower() if request.primary_email else None
+        request.alt_emails = [email.strip().lower() for email in request.alt_emails]
+        request.remove_emails = [email.strip().lower() for email in request.remove_emails]
+
+        # Find student by Google Form email
+        student_email_entry = db.query(StudentEmail).filter(
+            func.lower(StudentEmail.email) == google_form_email
+        ).first()
+
+        # Check if student was found
+        if not student_email_entry:
+            raise HTTPException(status_code=404, detail="Student not found")
+
+        student = db.query(Student).filter(Student.cti_id == student_email_entry.cti_id).first()
+        if not student:
+            raise HTTPException(status_code=404, detail="Student not found")
+
+        # Fetch all student emails
+        student_emails = db.query(StudentEmail).filter(StudentEmail.cti_id == student.cti_id).all()
+        student_email_dict = {email.email.lower(): email for email in student_emails} 
+        student_email_list = set(student_email_dict.keys())
+
+        # Ensure new alternate emails do not belong to another student
+        for email_lower in request.alt_emails:
+            email_owner = db.query(StudentEmail).filter(func.lower(StudentEmail.email) == email_lower).first()
+            if email_owner and email_owner.cti_id != student.cti_id:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Email '{email_lower}' is already associated with another student"
+                )
+
+        # Handle email removal
+        for email_lower in request.remove_emails:
+            if email_lower not in student_email_list:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Cannot remove email: {email_lower} not found in student record"
+                )
+            
+            # Prevent removal of primary email
+            if student_email_dict[email_lower].is_primary:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Cannot remove primary email: {email_lower}"
+                )
+
+            db.query(StudentEmail).filter(
+                StudentEmail.cti_id == student.cti_id,
+                func.lower(StudentEmail.email) == email_lower
+            ).delete()
+            student_email_list.remove(email_lower)
+
+        # Add new alternate emails
+        for email_lower in request.alt_emails:
+            if email_lower not in student_email_list:
+                new_email = StudentEmail(email=email_lower, cti_id=student.cti_id, is_primary=False)
+                db.add(new_email)
+                student_email_list.add(email_lower)
+
+        # Handle primary email update
+        if request_primary_email:
+            new_primary_email = student_email_dict.get(request_primary_email)
+            if not new_primary_email and request_primary_email in request.alt_emails:
+                new_primary_email = StudentEmail(email=request_primary_email, cti_id=student.cti_id, is_primary=False)
+                db.add(new_primary_email)
+                db.commit()
+                db.refresh(new_primary_email)
+                student_email_dict[request_primary_email] = new_primary_email
+            if request_primary_email not in student_email_dict:
+                raise HTTPException(status_code=403, detail="Primary email must be an existing or newly added student email")
+            db.query(StudentEmail).filter(StudentEmail.cti_id == student.cti_id).update({"is_primary": False})
+            student_email_dict[request_primary_email].is_primary = True
+
+        db.commit()
+        return {"status": 200}
+
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")

--- a/src/main.py
+++ b/src/main.py
@@ -44,8 +44,8 @@ def database_test(db: Session = Depends(make_session)):
     try:
         exists = db.query(Student).first()
         if exists:
-            return StudentSchema.model_validate(Student)
-            # return StudentSchema.model_validate(exists)
+            # return StudentSchema.model_validate(Student)
+            return StudentSchema.model_validate(exists)
         else:
             return {"message": "Database Accessible, but contains no data"}
     except SQLAlchemyError:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,8 @@ from sqlalchemy.orm import Session
 from unittest.mock import MagicMock
 from src.app.database import make_session
 from src.app.models.postgres.models import Student, StudentEmail
+from sqlalchemy.exc import SQLAlchemyError
+
 
 client = TestClient(app)
 
@@ -192,14 +194,21 @@ class TestModifyAlternateEmails:
     
     def test_add_alternate_emails(self, mock_postgresql_db):
         """Test adding alternate emails for a student."""
-        student_email = [StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)]
-        
-        # Mock database response for existing student email
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_email
+        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
+        student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
+
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            student_email,
+            student,
+            None,
+            None,
+        ]
+
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [
+            student_email
+        ]
 
         response = client.post("/api/students/alternate-emails", json={
-            "fname": "Nicolas",
-            "lname": "Guerrero",
             "alt_emails": ["newemail@email.com", "newemail2@email.com"],
             "google_form_email": "ngcti@email.com"
         })
@@ -213,157 +222,179 @@ class TestModifyAlternateEmails:
         student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
         other_student_email = StudentEmail(email="someoneelse@email.com", cti_id=2, is_primary=True)
 
-        # Mock database responses for email checks
         mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
             student_email,
-            student, 
+            student,    
             other_student_email,
         ]
 
         mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [student_email]
 
         response = client.post("/api/students/alternate-emails", json={
-            "fname": "Nicolas",
-            "lname": "Guerrero",
             "alt_emails": ["someoneelse@email.com"],
-            "google_form_email": "ngcti@email.com"
+            "google_form_email": "ngcti@email.com",
         })
 
         assert response.status_code == 403
         assert "already associated with another student" in response.json().get("detail", "")
 
-    def test_set_existing_alternate_as_primary(self, mock_postgresql_db):
-        """Test setting an existing alternate email as the primary email."""
-        student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
-        alt_email = StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
-
-        # Mock database response for existing student emails
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [
-            student_email,
-            alt_email,
-        ]
-
-        response = client.post("/api/students/alternate-emails", json={
-            "fname": "Nicolas",
-            "lname": "Guerrero",
-            "primary_email": "alt@email.com",
-            "google_form_email": "ngcti@email.com"
-        })
-
-        assert response.status_code == 200
-
-    def test_add_alternate_and_set_as_primary(self, mock_postgresql_db):
-        """Test adding an alternate email and setting it as primary at the same time."""
-        student_email = [StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)]
-
-        # Mock database response for existing student emails
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_email
-
-        response = client.post("/api/students/alternate-emails", json={
-            "fname": "Nicolas",
-            "lname": "Guerrero",
-            "alt_emails": ["newprimary@email.com"],
-            "primary_email": "newprimary@email.com",
-            "google_form_email": "ngcti@email.com"
-        })
-
-        assert response.status_code == 200
-
-    def test_set_invalid_primary_email(self, mock_postgresql_db):
-        """Test setting an invalid email as primary (not associated with the student)."""
-        student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
-        alt_email = StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
-
-        # Mock database response for existing student emails
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [
-            student_email,
-            alt_email,
-        ]
-
-        response = client.post("/api/students/alternate-emails", json={
-            "fname": "Nicolas",
-            "lname": "Guerrero",
-            "primary_email": "notregistered@email.com",
-            "google_form_email": "ngcti@email.com"
-        })
-
-        assert response.status_code == 403
-        assert "Primary email must be an existing or newly added student email" in response.json()["detail"]
-
-    def test_cannot_remove_primary_email(self, mock_postgresql_db):
-        """Test that attempting to remove the primary email results in an error."""
-        student_emails = [
-            StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True),
-            StudentEmail(email="alt@email.com", cti_id=1, is_primary=False),
-            StudentEmail(email="alt2@email.com", cti_id=1, is_primary=False)
-        ]
-
-        # Mock database response for existing student emails
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
-        mock_postgresql_db.query.return_value.filter.return_value.first.return_value = student_emails[0]
-
-        response = client.post("/api/students/alternate-emails", json={
-            "fname": "Nicolas",
-            "lname": "Guerrero",
-            "remove_emails": ["ngcti@email.com"],
-            "google_form_email": "ngcti@email.com"
-        })
-
-        assert response.status_code == 403
-        assert "Cannot remove primary email" in response.json()["detail"]
-
-    def test_remove_alternate_email_success(self, mock_postgresql_db):
-        """Test successfully removing an alternate email."""
-        student_emails = [
-            StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True),
-            StudentEmail(email="alt@email.com", cti_id=1, is_primary=False),
-        ]
-
-        # Mock database response for existing student emails
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
-
-        response = client.post("/api/students/alternate-emails", json={
-            "fname": "Nicolas",
-            "lname": "Guerrero",
-            "remove_emails": ["alt@email.com"],
-            "google_form_email": "ngcti@email.com"
-        })
-
-        assert response.status_code == 200
-        assert response.json() == {"status": 200}
-
-    def test_remove_nonexistent_alternate_email(self, mock_postgresql_db):
-        """Test removing an alternate email that does not exist in the student record."""
-        student_emails = [StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)]
-
-        # Mock database response for existing student emails
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
-
-        response = client.post("/api/students/alternate-emails", json={
-            "fname": "Nicolas",
-            "lname": "Guerrero",
-            "remove_emails": ["notfound@email.com"],
-            "google_form_email": "ngcti@email.com"
-        })
-
-        assert response.status_code == 400
-        assert "not found in student record" in response.json()["detail"]
-
-    def test_student_not_found(self, mock_postgresql_db):
-        """Test where the student is not found in the database."""
+    def test_student_not_found_by_email(self, mock_postgresql_db):
+        """Test where the student email is not found in the database."""
         mock_postgresql_db.query.return_value.filter.return_value.first.return_value = None
 
         response = client.post("/api/students/alternate-emails", json={
-            "fname": "John",
-            "lname": "Doe",
             "alt_emails": ["newalt@email.com"],
-            "google_form_email": "ngcti@email.com"
+            "google_form_email": "notfound@email.com",
         })
 
         assert response.status_code == 404
         assert "Student not found" in response.json()["detail"]
 
+    def test_remove_alternate_email_success(self, mock_postgresql_db):
+        """Test successfully removing an alternate email."""
+        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
+        student_emails = [
+            StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True),
+            StudentEmail(email="alt@email.com", cti_id=1, is_primary=False),
+        ]
+
+        # Mock database
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            student_emails[0], 
+            student       
+        ]
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
+
+        response = client.post("/api/students/alternate-emails", json={
+            "alt_emails": [],
+            "remove_emails": ["alt@email.com"],
+            "google_form_email": "ngcti@email.com",
+        })
+
+        assert response.status_code == 200
+        assert response.json() == {"status": 200}
+
+    def test_skip_nonexistent_email_removal(self, mock_postgresql_db):
+        """Test that attempting to remove a nonexistent email is silently skipped."""
+        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
+        student_emails = [StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)]
+
+        # Mock database 
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            student_emails[0],  
+            student         
+        ]
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
+
+        response = client.post("/api/students/alternate-emails", json={
+            "alt_emails": [],
+            "remove_emails": ["notfound@email.com"],
+            "google_form_email": "ngcti@email.com",
+        })
+
+        assert response.status_code == 200
+        assert response.json() == {"status": 200}
+
+    def test_primary_email_must_match_form_email(self, mock_postgresql_db):
+        """Test that primary_email must match the google_form_email."""
+        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
+        student_emails = [
+            StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True),
+            StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
+        ]
+
+        # Mock database
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            student_emails[0],  
+            student            
+        ]
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
+
+        response = client.post("/api/students/alternate-emails", json={
+            "alt_emails": [],
+            "remove_emails": [],
+            "primary_email": "alt@email.com",  # Doesn't match google_form_email
+            "google_form_email": "ngcti@email.com",
+        })
+
+        assert response.status_code == 403
+        assert "Primary email must match the email used to submit the form" in response.json()["detail"]
+
+    def test_add_and_remove_email_together(self, mock_postgresql_db):
+        """Test adding a new email and removing an existing one in the same request."""
+        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
+        student_emails = [
+            StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True),
+            StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
+        ]
+
+        # Mock database
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            student_emails[0],
+            student,
+            None
+        ]
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
+
+        response = client.post("/api/students/alternate-emails", json={
+            "alt_emails": ["new@email.com"],
+            "remove_emails": ["alt@email.com"],
+            "google_form_email": "ngcti@email.com",
+        })
+
+        assert response.status_code == 200
+        assert response.json() == {"status": 200}
+
+    def test_skip_email_in_both_add_and_remove(self, mock_postgresql_db):
+        """Test that an email in both alt_emails and remove_emails is skipped."""
+        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
+        student_emails = [StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)]
+
+        # Mock database 
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            student_emails[0],
+            student
+        ]
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
+
+        response = client.post("/api/students/alternate-emails", json={
+            "alt_emails": ["new@email.com"],
+            "remove_emails": ["new@email.com"],  # Same email in both lists
+            "google_form_email": "ngcti@email.com",
+        })
+
+        assert response.status_code == 200
+        assert response.json() == {"status": 200}
+
+    def test_database_error_handling(self, mock_postgresql_db):
+        """Test handling of SQLAlchemy database errors."""
+        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
+        student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
+        
+        # Mock database
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            student_email, 
+            student,
+            None
+        ]
+        
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [student_email]
+        
+        # Simulate database error
+        mock_postgresql_db.commit.side_effect = SQLAlchemyError("Database error")
+
+        response = client.post("/api/students/alternate-emails", json={
+            "alt_emails": ["newemail@email.com"],
+            "remove_emails": [],
+            "google_form_email": "ngcti@email.com",
+        })
+
+        assert response.status_code == 500
+        assert "Database error" in response.json()["detail"]
+        assert mock_postgresql_db.rollback.called
+
     def test_empty_request_validation_fail(self, mock_postgresql_db):
         """Test that an empty request body fails validation."""
         response = client.post("/api/students/alternate-emails", json={})
         assert response.status_code == 422
+        


### PR DESCRIPTION
## Alternate email address processing

This PR adds the endpoint for handling alternate email address submissions. Students can modify the email addresses registered under their account and designate their primary email for CTI communications.

### Changes Included
Implemented `POST /api/students/alternate-emails` endpoint.
* Add Alternate Emails – Allows students to add new emails, ensuring they aren’t linked to another student.
* Remove Alternate Emails – Deletes emails from a student’s record.
* Set Primary Email – Updates the primary email if its similar to the google form email.
* Enforce Email Uniqueness – Ensures each email belongs to only one student, rejecting duplicates.
* Prevent Primary Email Removal Without Reassignment – Blocks removal of the primary email unless a new one is set first.
* Authenticate Using Google Form Email – Identifies students via their submitted Google Form email

### Issues Fixed
* https://github.com/NickGuerrero/cti-sys/issues/12

### Tests

`TestModifyAlternateEmails` pytest class includes:
* 5 success tests (adding, removing, setting primary).
* 5 failure tests (conflicting emails, removing primary, invalid primary).

To run tests locally:
```
pytest -v -k "TestModifyAlternateEmails"
```

<img width="1028" alt="Screenshot 2025-03-08 at 3 58 53 PM" src="https://github.com/user-attachments/assets/6d6329fa-7b5b-4e44-a9cb-a7f410f82486" />


On Github Actions:

```
pytest -v -m "not integration"
```
<img width="1379" alt="Screenshot 2025-03-08 at 3 59 56 PM" src="https://github.com/user-attachments/assets/5dbca635-a04c-4544-a56f-3d1a48bd67e2" />


### Authentication Consideration
* Currently, authentication is handled by using the email submitted via the Google Form to identify the student.

### Notes on Library changes
* psycopg-binary version 3.2.3 no longer exists
```
(venv) (base) erfanarsala@MacBook-Pro-2 cti-sys % pip3 index versions psycopg-binary 
psycopg-binary (3.2.5)
Available versions: 3.2.5, 3.2.4, 3.1.19, 3.1.18, 3.1.17, 3.1.16, 3.1.15, 3.1.14, 3.1.13, 3.1.12
  INSTALLED: 3.2.4
  LATEST:    3.2.5
```
### Checklist
- [x] I've reviewed the contribution guide
- [x] I've confirmed the changes work on my machine
- [x] This pull request is ready for review