### PR TITLE
Alternate email improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ pymongo==4.10.1
 pytest==8.3.4
 pytest-cov==4.1.0
 mongomock==4.3.0
+pydantic-settings==2.8.1

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,15 @@
+from pydantic_settings import BaseSettings
+
 # Consider moving into a pydantic-settings package's `class Settings(BaseSettings)` for environment-specific overrides
+
+class Settings(BaseSettings):
+    app_env: str = "development"
+
+    model_config = {
+        "case_sensitive": False,
+    }
+
+settings = Settings()
 
 # MongoDB
 MONGO_DATABASE_NAME = "cti_mongo_db"

--- a/src/students/alternate_emails/service.py
+++ b/src/students/alternate_emails/service.py
@@ -4,20 +4,56 @@ from sqlalchemy.orm import Session
 
 from src.database.postgres.models import Student, StudentEmail
 from src.students.alternate_emails.schemas import AlternateEmailRequest
+from typing import List, Optional, Dict, Any
 
-def modify(*, request: AlternateEmailRequest, db: Session) -> None:
-    # Normalize all emails to lowercase and strip whitespace
-    google_form_email = request.google_form_email.strip().lower()
-    request_primary_email = request.primary_email.strip().lower() if request.primary_email else None
-    request.alt_emails = [email.strip().lower() for email in request.alt_emails]
-    request.remove_emails = [email.strip().lower() for email in request.remove_emails]
+def fetch_current_emails(google_form_email: str, db: Session) -> Dict[str, Any]:
+    """
+    Retrieve all email addresses associated with the student identified by the given Google Form email.
 
-    # Find student by Google Form email
+    This function performs a case-insensitive search for the student's email record,
+    then fetches all associated emails—including the primary email—and returns them in a dictionary
+    for easy JSON conversion. It is primarily used for testing.
+    """
+    # Query for the email record using a case-insensitive match.
+    email_record = db.query(StudentEmail).filter(
+        func.lower(StudentEmail.email) == google_form_email
+    ).first()
+
+    if not email_record:
+        return {"emails": [], "primary_email": None}
+
+    # Retrieve the student's unique identifier.
+    cti_id = email_record.cti_id
+
+    # Query for all emails associated with this student.
+    all_emails = db.query(StudentEmail).filter(StudentEmail.cti_id == cti_id).all()
+
+    primary_email = None
+    email_list = []
+    # Build a list of emails and identify the primary email.
+    for e in all_emails:
+        email_list.append(e.email)
+        if e.is_primary:
+            primary_email = e.email
+
+    return {
+        "emails": email_list,
+        "primary_email": primary_email,
+    }
+
+
+def find_student_by_google_email(google_form_email: str, db: Session) -> Student:
+    """
+    Retrieve the student associated with the given Google Form email.
+
+    This function locates the StudentEmail record using a case insensitive match, then retrieves
+    the corresponding Student based on the student's unique identifier. If either record is missing,
+    an HTTP 404 error is raised.
+    """
     student_email_entry = db.query(StudentEmail).filter(
         func.lower(StudentEmail.email) == google_form_email
     ).first()
 
-    # Check if student was found
     if not student_email_entry:
         raise HTTPException(status_code=404, detail="Student not found")
 
@@ -25,69 +61,175 @@ def modify(*, request: AlternateEmailRequest, db: Session) -> None:
     if not student:
         raise HTTPException(status_code=404, detail="Student not found")
 
-    # Fetch all student emails and normalize to lowercase for comparisons
+    return student
+
+
+def remove_student_email(
+    student: Student,
+    emails_to_remove: List[str],
+    new_primary_email: Optional[str],
+    db: Session,
+) -> None:
+    """
+    Remove specified email addresses from the student's record.
+
+    This function deletes emails listed in emails_to_remove. It prevents removal of the primary email
+    unless a new primary email is provided, otherwise, it raises an HTTP error.
+    """
+    if not emails_to_remove:
+        return
+
+    # Fetch all emails associated with the student.
     student_emails = db.query(StudentEmail).filter(StudentEmail.cti_id == student.cti_id).all()
-    student_email_dict = {email.email.lower(): email for email in student_emails} 
-    student_email_list = set(student_email_dict.keys())
+    student_email_dict = {email.email.lower(): email for email in student_emails}
+
+    for email_lower in emails_to_remove:
+        email_record = student_email_dict.get(email_lower)
+        
+        if not email_record:
+            continue
     
-    # Ensure primary email change authentication
-    if request_primary_email:
-        # If changing primary email, it must match the Google form email
-        if request_primary_email != google_form_email:
-            raise HTTPException(
-                status_code=403,
-                detail="Primary email must match the email used to submit the form"
-            )
+        # if not email_record:
+        #     raise HTTPException(
+        #         status_code=404, 
+        #         detail=f"Email '{email_lower}' not found for the student."
+        #     )
 
-    # Handle email removal
-    for email_lower in request.remove_emails:
-        if email_lower not in student_email_list:
-            continue 
+        # Prevent removal of the primary email without specifying a new one.
+        if email_record.is_primary and not new_primary_email:
+            msg = f"Cannot remove primary email '{email_lower}' without specifying a new primary email."
+            raise HTTPException(status_code=403, detail=msg)
 
-        # Prevent removal of primary email unless a new primary is specified
-        if student_email_dict[email_lower].is_primary and not request_primary_email:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Cannot remove primary email: {email_lower} without specifying a new primary email"
-            )
-
-        # Delete the email
+        # Delete the email record.
         db.query(StudentEmail).filter(
             StudentEmail.cti_id == student.cti_id,
             func.lower(StudentEmail.email) == email_lower
         ).delete()
-        student_email_list.remove(email_lower)
 
-    # Ensure new alternate emails do not belong to another student
-    for email_lower in request.alt_emails:
-        if email_lower in request.remove_emails:
+
+def add_alternate_emails(
+    student: Student,
+    alt_emails: List[str],
+    removed_emails: List[str],
+    db: Session,
+) -> None:
+    """
+    Add new alternate email addresses to the student's record.
+
+    This function adds each email in alt_emails that is not already associated with the student or
+    scheduled for removal. It also verifies that the email is not already used by another student,
+    raising an HTTP error if it is.
+    """
+    if not alt_emails:
+        return
+
+    # Retrieve all current emails for the student.
+    student_email_records = db.query(StudentEmail).filter(
+        StudentEmail.cti_id == student.cti_id
+    ).all()
+
+    existing_emails = {email.email.lower() for email in student_email_records}
+
+    for email_lower in alt_emails:
+        # Skip if the email is scheduled for removal or already exists.
+        if email_lower in removed_emails or email_lower in existing_emails:
             continue
-            
-        if email_lower not in student_email_list:
-            # Check if email belongs to another student
-            email_owner = db.query(StudentEmail).filter(
-                func.lower(StudentEmail.email) == email_lower
-            ).first()
-            
-            if email_owner and email_owner.cti_id != student.cti_id:
-                raise HTTPException(
-                    status_code=403,
-                    detail=f"Email '{email_lower}' is already associated with another student"
-                )
-                
-            # Add new email
-            new_email = StudentEmail(email=email_lower, cti_id=student.cti_id, is_primary=False)
-            db.add(new_email)
-            student_email_list.add(email_lower)
 
-    # Handle primary email update
-    if request_primary_email:
-        db.query(StudentEmail).filter(StudentEmail.cti_id == student.cti_id).update({"is_primary": False})
-        
-        # Set the requested email as primary
-        db.query(StudentEmail).filter(
-            StudentEmail.cti_id == student.cti_id,
-            func.lower(StudentEmail.email) == request_primary_email
-        ).update({"is_primary": True})
+        # Check if the email is already associated with another student.
+        existing_owner = db.query(StudentEmail).filter(
+            func.lower(StudentEmail.email) == email_lower
+        ).first()
 
+        if existing_owner and existing_owner.cti_id != student.cti_id:
+            msg = f"Email '{email_lower}' is already associated with another student."
+            raise HTTPException(status_code=403, detail=msg)
+
+        # Add the new alternate email.
+        new_email = StudentEmail(
+            email=email_lower,
+            cti_id=student.cti_id,
+            is_primary=False,
+        )
+        db.add(new_email)
+
+
+def update_primary_email(
+    student: Student,
+    request_primary_email: Optional[str],
+    google_form_email: str,
+    db: Session
+) -> None:
+    """
+    Update the student's primary email address.
+
+    The new primary email must match the normalized Google Form email. All existing email records are
+    reset to non primary, and the record corresponding to the new primary email is updated.
+    If the update fails (for example, if the email is not found), an HTTP error is raised.
+    """
+    if not request_primary_email:
+        return
+
+    if request_primary_email.lower() != google_form_email:
+        raise HTTPException(
+            status_code=403,
+            detail="Primary email must match the email used to submit the form."
+        )
+
+    # Reset all emails for the student to non-primary.
+    db.query(StudentEmail).filter(
+        StudentEmail.cti_id == student.cti_id
+    ).update({"is_primary": False})
+
+    # Update the new primary email.
+    updated_rows = db.query(StudentEmail).filter(
+        StudentEmail.cti_id == student.cti_id,
+        func.lower(StudentEmail.email) == request_primary_email.lower()
+    ).update({"is_primary": True})
+
+    if not updated_rows:
+        msg = f"Could not set '{request_primary_email}' as primary (email not found)."
+        raise HTTPException(status_code=404, detail=msg)
+    
+def modify(*, request: AlternateEmailRequest, db: Session) -> None:
+    """
+    Main entry point to modify alternate emails.
+    """
+
+    # Step 1: remove leading/trailing spaces and convert to lowercase.
+    google_form_email = request.google_form_email.strip().lower()
+    primary_email = request.primary_email.strip().lower() if request.primary_email else None
+    alt_emails = [email.strip().lower() for email in request.alt_emails]
+    remove_emails = [email.strip().lower() for email in request.remove_emails]
+
+    # Step 2: Retrieve the student record using the normalized Google Form email.
+    student = find_student_by_google_email(google_form_email, db)
+
+    # Step 3: Remove emails from the student's record.
+    # This ensures that emails flagged for removal are deleted, and if removing a primary email,
+    # a new primary email must be specified.
+    remove_student_email(
+        student=student,
+        emails_to_remove=remove_emails,
+        new_primary_email=primary_email,
+        db=db
+    )
+
+    # Step 4: Add any new alternate emails.
+    # This step adds new emails while verifying that they are not already in use by another student.
+    add_alternate_emails(
+        student=student,
+        alt_emails=alt_emails,
+        removed_emails=remove_emails,
+        db=db
+    )
+
+    # Step 5: Update the primary email if a new one is provided.
+    update_primary_email(
+        student=student,
+        request_primary_email=primary_email,
+        google_form_email=google_form_email,
+        db=db
+    )
+
+    # Step 6: Commit the transaction to save all changes to the database.
     db.commit()

--- a/src/students/alternate_emails/service.py
+++ b/src/students/alternate_emails/service.py
@@ -14,7 +14,7 @@ def fetch_current_emails(google_form_email: str, db: Session) -> Dict[str, Any]:
     then fetches all associated emails—including the primary email—and returns them in a dictionary
     for easy JSON conversion. It is primarily used for testing.
     """
-    # Query for the email record using a case-insensitive match.
+    # Query for the email record using a case insensitive match.
     email_record = db.query(StudentEmail).filter(
         func.lower(StudentEmail.email) == google_form_email
     ).first()
@@ -131,7 +131,7 @@ def add_alternate_emails(
     existing_emails = {email.email.lower() for email in student_email_records}
 
     for email_lower in alt_emails:
-        # Skip if the email is scheduled for removal or already exists.
+        # Skip if it's in both add and remove lists or if student already has this email.
         if email_lower in removed_emails or email_lower in existing_emails:
             continue
 
@@ -231,5 +231,5 @@ def modify(*, request: AlternateEmailRequest, db: Session) -> None:
         db=db
     )
 
-    # Step 6: Commit the transaction to save all changes to the database.
+    # Step 6: Commit all changes to the database.
     db.commit()

--- a/tests/students/alternate_emails/test_students_alternate_emails_router.py
+++ b/tests/students/alternate_emails/test_students_alternate_emails_router.py
@@ -1,214 +1,300 @@
 from fastapi.testclient import TestClient
-from sqlalchemy.exc import SQLAlchemyError
+import pytest
 
 from src.database.postgres.models import Student, StudentEmail
 from src.main import app
+from src.config import settings
 
 client = TestClient(app)
 
 class TestModifyAlternateEmails:
-    def test_add_alternate_emails(self, mock_postgresql_db):
+    # =========================
+    # Successful Modifications
+    # =========================
+
+    @pytest.mark.parametrize("env", ["production", "development"])
+    def test_add_alternate_emails(self, env, monkeypatch, mock_postgresql_db):
         """Test adding alternate emails for a student."""
-        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
-        student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
+        monkeypatch.setattr(settings, "app_env", env)
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
+        primary_email = StudentEmail(email="primary@example.com", cti_id=1, is_primary=True)
+        new_email_1 = StudentEmail(email="new1@example.com", cti_id=1, is_primary=False)
+        new_email_2 = StudentEmail(email="new2@example.com", cti_id=1, is_primary=False)
 
+        # Lookup and student record fetch.
         mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
-            student_email,
-            student,
-            None,
-            None,
+            primary_email,  # initial primary fetch in find_student_by_google_email
+            student,        # student record lookup
+            None,           # new_email_1 not found
+            None,           # new_email_2 not found
+            primary_email   # final fetch in fetch_current_emails
         ]
-
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [
-            student_email
+        # Simulate before and after modifications.
+        mock_postgresql_db.query.return_value.filter.return_value.all.side_effect = [
+            [primary_email],
+            [primary_email, new_email_1, new_email_2]
         ]
+        query = mock_postgresql_db.query.return_value.filter.return_value
+        query.update.return_value = 1
+        query.delete.return_value = 1
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.rollback.return_value = None
 
         response = client.post("/api/students/alternate-emails", json={
-            "alt_emails": ["newemail@email.com", "newemail2@email.com"],
-            "google_form_email": "ngcti@email.com"
+            "alt_emails": [new_email_1.email, new_email_2.email],
+            "google_form_email": primary_email.email,
+            "primary_email": primary_email.email
         })
 
         assert response.status_code == 200
-        assert response.json() == {"status": 200}
-    
-    def test_add_alternate_email_already_exists(self, mock_postgresql_db):
-        """Test adding an alternate email that already belongs to another student."""
-        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
+        data = response.json()
+        if env == "production":
+            assert data == {"status": 200}
+        else:
+            assert data["status"] == 200
+            assert "emails" in data and "primary_email" in data
+            emails_lower = [e.lower() for e in data["emails"]]
+            assert new_email_1.email.lower() in emails_lower
+            assert new_email_2.email.lower() in emails_lower
+            assert data["primary_email"].lower() == primary_email.email.lower()
+
+    @pytest.mark.parametrize("env", ["production", "development"])
+    def test_remove_alternate_email_success(self, env, monkeypatch, mock_postgresql_db):
+        """Test successfully removing an alternate email."""
+        monkeypatch.setattr(settings, "app_env", env)
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
+        primary = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
+        alternate = StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
+
+        # Lookup and student record fetch.
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            primary,  # find_student_by_google_email
+            student,  # student record
+            primary   # update_primary_email later
+        ]
+        # First call returns both emails, second call returns only the primary.
+        mock_postgresql_db.query.return_value.filter.return_value.all.side_effect = [
+            [primary, alternate],
+            [primary]
+        ]
+        query = mock_postgresql_db.query.return_value.filter.return_value
+        query.update.return_value = 1
+        query.delete.return_value = 1
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.rollback.return_value = None
+
+        response = client.post("/api/students/alternate-emails", json={
+            "alt_emails": [],
+            "remove_emails": [alternate.email],
+            "google_form_email": primary.email,
+            "primary_email": primary.email
+        })
+
+        assert response.status_code == 200
+        data = response.json()
+        if env == "production":
+            assert data == {"status": 200}
+        else:
+            emails_lower = [e.lower() for e in data["emails"]]
+            assert primary.email.lower() in emails_lower
+            assert data["primary_email"].lower() == primary.email.lower()
+
+    @pytest.mark.parametrize("env", ["production", "development"])
+    def test_update_primary_email(self, env, monkeypatch, mock_postgresql_db):
+        """
+        Test changing the primary email without removing any emails.
+        Initially, the student has 'old@example.com' as primary and 'new@example.com' as an alternate.
+        The request changes the primary email to 'new@example.com'.
+        """
+        monkeypatch.setattr(settings, "app_env", env)
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
+        old_email = StudentEmail(email="old@example.com", cti_id=1, is_primary=True)
+        new_email = StudentEmail(email="new@example.com", cti_id=1, is_primary=False)
+
+        # Lookup and student record fetch.
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            new_email,  # lookup by google_form_email returns the alternate
+            student,    # fetch student record
+            new_email   # fetch_current_emails returns new_email as primary
+        ]
+        # new_email is now primary and old_email remains non primary.
+        updated_old_email = StudentEmail(email="old@example.com", cti_id=1, is_primary=False)
+        updated_new_email = StudentEmail(email="new@example.com", cti_id=1, is_primary=True)
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [
+            updated_old_email, updated_new_email
+        ]
+        query = mock_postgresql_db.query.return_value.filter.return_value
+        query.update.side_effect = [1, 1]
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.rollback.return_value = None
+
+        response = client.post("/api/students/alternate-emails", json={
+            "alt_emails": [],
+            "remove_emails": [],
+            "google_form_email": new_email.email,
+            "primary_email": new_email.email
+        })
+
+        assert response.status_code == 200
+        data = response.json()
+        if env == "production":
+            assert data == {"status": 200}
+        else:
+            assert data["status"] == 200
+            assert "emails" in data
+            emails_lower = [e.lower() for e in data["emails"]]
+            # Verify both emails remain and primary is updated.
+            assert old_email.email.lower() in emails_lower
+            assert new_email.email.lower() in emails_lower
+            assert data["primary_email"].lower() == new_email.email.lower()
+
+    # ====================
+    # Error Conditions
+    # ====================
+
+    def test_add_alternate_email_already_exists(self, monkeypatch, mock_postgresql_db):
+        """Test error when an alternate email is already associated with another student."""
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
         student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
         other_student_email = StudentEmail(email="someoneelse@email.com", cti_id=2, is_primary=True)
 
         mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
-            student_email,
-            student,    
-            other_student_email,
+            student_email,      # student's email record found
+            student,            # student record found
+            other_student_email # alternate email belongs to another student
         ]
-
         mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [student_email]
 
         response = client.post("/api/students/alternate-emails", json={
-            "alt_emails": ["someoneelse@email.com"],
-            "google_form_email": "ngcti@email.com",
+            "alt_emails": [other_student_email.email],
+            "google_form_email": student_email.email,
+            "primary_email": student_email.email
         })
 
         assert response.status_code == 403
-        assert "already associated with another student" in response.json().get("detail", "")
+        detail = response.json().get("detail", "")
+        assert "already associated with another student" in detail
 
-    def test_student_not_found_by_email(self, mock_postgresql_db):
-        """Test where the student email is not found in the database."""
+    def test_student_not_found_by_email(self, monkeypatch, mock_postgresql_db):
+        """Test error when no student is found for the given Google Form email."""
         mock_postgresql_db.query.return_value.filter.return_value.first.return_value = None
 
         response = client.post("/api/students/alternate-emails", json={
             "alt_emails": ["newalt@email.com"],
             "google_form_email": "notfound@email.com",
+            "primary_email": "notfound@email.com"
         })
 
         assert response.status_code == 404
-        assert "Student not found" in response.json()["detail"]
+        assert "Student not found" in response.json().get("detail", "")
 
-    def test_remove_alternate_email_success(self, mock_postgresql_db):
-        """Test successfully removing an alternate email."""
-        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
-        student_emails = [
-            StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True),
-            StudentEmail(email="alt@email.com", cti_id=1, is_primary=False),
-        ]
+    def test_primary_email_must_match_form_email(self, monkeypatch, mock_postgresql_db):
+        """Test error when provided primary email does not match the email used in the form."""
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
+        primary = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
+        alternate = StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
 
-        # Mock database
         mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
-            student_emails[0], 
-            student       
+            primary,  # returns student's primary email
+            student   # returns student record
         ]
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
-
-        response = client.post("/api/students/alternate-emails", json={
-            "alt_emails": [],
-            "remove_emails": ["alt@email.com"],
-            "google_form_email": "ngcti@email.com",
-        })
-
-        assert response.status_code == 200
-        assert response.json() == {"status": 200}
-
-    def test_skip_nonexistent_email_removal(self, mock_postgresql_db):
-        """Test that attempting to remove a nonexistent email is silently skipped."""
-        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
-        student_emails = [StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)]
-
-        # Mock database 
-        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
-            student_emails[0],  
-            student         
-        ]
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
-
-        response = client.post("/api/students/alternate-emails", json={
-            "alt_emails": [],
-            "remove_emails": ["notfound@email.com"],
-            "google_form_email": "ngcti@email.com",
-        })
-
-        assert response.status_code == 200
-        assert response.json() == {"status": 200}
-
-    def test_primary_email_must_match_form_email(self, mock_postgresql_db):
-        """Test that primary_email must match the google_form_email."""
-        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
-        student_emails = [
-            StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True),
-            StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
-        ]
-
-        # Mock database
-        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
-            student_emails[0],  
-            student            
-        ]
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [primary, alternate]
 
         response = client.post("/api/students/alternate-emails", json={
             "alt_emails": [],
             "remove_emails": [],
-            "primary_email": "alt@email.com",  # Doesn't match google_form_email
-            "google_form_email": "ngcti@email.com",
+            "primary_email": alternate.email,
+            "google_form_email": primary.email
         })
 
         assert response.status_code == 403
-        assert "Primary email must match the email used to submit the form" in response.json()["detail"]
+        assert "Primary email must match the email used to submit the form" in response.json().get("detail", "")
 
-    def test_add_and_remove_email_together(self, mock_postgresql_db):
-        """Test adding a new email and removing an existing one in the same request."""
-        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
-        student_emails = [
-            StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True),
-            StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
-        ]
+    def test_skip_nonexistent_email_removal(self, monkeypatch, mock_postgresql_db):
+        """Test that removal skips emails not found in the student record."""
+        monkeypatch.setattr(settings, "app_env", "development")
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
+        primary = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
+        alt = StudentEmail(email="alt@email.com", cti_id=1, is_primary=False)
 
-        # Mock database
         mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
-            student_emails[0],
-            student,
-            None
+            primary,  # primary lookup
+            student,  # student record
+            primary   # for update_primary_email
         ]
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
+        mock_postgresql_db.query.return_value.filter.return_value.all.side_effect = [
+            [primary, alt],
+            [primary]
+        ]
+        query = mock_postgresql_db.query.return_value.filter.return_value
+        query.update.return_value = 1
+        query.delete.return_value = 1
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.rollback.return_value = None
 
         response = client.post("/api/students/alternate-emails", json={
-            "alt_emails": ["new@email.com"],
-            "remove_emails": ["alt@email.com"],
-            "google_form_email": "ngcti@email.com",
+            "alt_emails": [],
+            "remove_emails": ["notfound@email.com", alt.email],
+            "google_form_email": primary.email,
+            "primary_email": primary.email
         })
 
         assert response.status_code == 200
-        assert response.json() == {"status": 200}
+        data = response.json()
+        if settings.app_env == "production":
+            assert data == {"status": 200}
+        else:
+            emails_lower = [e.lower() for e in data["emails"]]
+            assert primary.email.lower() in emails_lower
+            assert alt.email.lower() not in emails_lower
+            assert data["primary_email"].lower() == primary.email.lower()
 
-    def test_skip_email_in_both_add_and_remove(self, mock_postgresql_db):
-        """Test that an email in both alt_emails and remove_emails is skipped."""
-        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
-        student_emails = [StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)]
+    def test_remove_primary_email_without_new_primary(self, monkeypatch, mock_postgresql_db):
+        """
+        Test error when attempting to remove the primary email without specifying a new primary.
+        """
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
+        primary = StudentEmail(email="primary@example.com", cti_id=1, is_primary=True)
 
-        # Mock database 
         mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
-            student_emails[0],
-            student
+            primary,  # primary email record
+            student   # student record
         ]
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = student_emails
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [primary]
 
         response = client.post("/api/students/alternate-emails", json={
-            "alt_emails": ["new@email.com"],
-            "remove_emails": ["new@email.com"],  # Same email in both lists
-            "google_form_email": "ngcti@email.com",
+            "alt_emails": [],
+            "remove_emails": [primary.email],
+            "google_form_email": primary.email,
+            "primary_email": ""
         })
 
-        assert response.status_code == 200
-        assert response.json() == {"status": 200}
+        assert response.status_code == 403
+        assert "Cannot remove primary email" in response.json().get("detail", "")
 
-    def test_database_error_handling(self, mock_postgresql_db):
-        """Test handling of SQLAlchemy database errors."""
-        student = Student(cti_id=1, fname="Nicolas", lname="Guerrero")
-        student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
-        
-        # Mock database
+    def test_update_primary_email_not_found(self, monkeypatch, mock_postgresql_db):
+        """
+        Test error when update for setting a new primary email fails.
+        """
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
+        primary = StudentEmail(email="primary@example.com", cti_id=1, is_primary=False)
+
         mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
-            student_email, 
-            student,
-            None
+            primary,  # lookup returns primary email record
+            student   # student record lookup
         ]
-        
-        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [student_email]
-        
-        # Simulate database error
-        mock_postgresql_db.commit.side_effect = SQLAlchemyError("Database error")
+        mock_postgresql_db.query.return_value.filter.return_value.all.return_value = [primary]
+        query = mock_postgresql_db.query.return_value.filter.return_value
+        query.update.side_effect = [1, 0]
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.rollback.return_value = None
 
         response = client.post("/api/students/alternate-emails", json={
-            "alt_emails": ["newemail@email.com"],
+            "alt_emails": [],
             "remove_emails": [],
-            "google_form_email": "ngcti@email.com",
+            "google_form_email": primary.email,
+            "primary_email": primary.email
         })
 
-        assert response.status_code == 500
-        assert "Database error" in response.json()["detail"]
-        assert mock_postgresql_db.rollback.called
-
-    def test_empty_request_validation_fail(self, mock_postgresql_db):
-        """Test that an empty request body fails validation."""
-        response = client.post("/api/students/alternate-emails", json={})
-        assert response.status_code == 422
+        assert response.status_code == 404
+        assert f"Could not set '{primary.email}' as primary" in response.json().get("detail", "")

--- a/tests/students/alternate_emails/test_students_alternate_emails_router.py
+++ b/tests/students/alternate_emails/test_students_alternate_emails_router.py
@@ -152,7 +152,7 @@ class TestModifyAlternateEmails:
     # Error Conditions
     # ====================
 
-    def test_add_alternate_email_already_exists(self, monkeypatch, mock_postgresql_db):
+    def test_add_alternate_email_already_exists(self, mock_postgresql_db):
         """Test error when an alternate email is already associated with another student."""
         student = Student(cti_id=1, fname="Jane", lname="Doe")
         student_email = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
@@ -175,7 +175,7 @@ class TestModifyAlternateEmails:
         detail = response.json().get("detail", "")
         assert "already associated with another student" in detail
 
-    def test_student_not_found_by_email(self, monkeypatch, mock_postgresql_db):
+    def test_student_not_found_by_email(self, mock_postgresql_db):
         """Test error when no student is found for the given Google Form email."""
         mock_postgresql_db.query.return_value.filter.return_value.first.return_value = None
 
@@ -188,7 +188,7 @@ class TestModifyAlternateEmails:
         assert response.status_code == 404
         assert "Student not found" in response.json().get("detail", "")
 
-    def test_primary_email_must_match_form_email(self, monkeypatch, mock_postgresql_db):
+    def test_primary_email_must_match_form_email(self, mock_postgresql_db):
         """Test error when provided primary email does not match the email used in the form."""
         student = Student(cti_id=1, fname="Jane", lname="Doe")
         primary = StudentEmail(email="ngcti@email.com", cti_id=1, is_primary=True)
@@ -249,7 +249,7 @@ class TestModifyAlternateEmails:
             assert alt.email.lower() not in emails_lower
             assert data["primary_email"].lower() == primary.email.lower()
 
-    def test_remove_primary_email_without_new_primary(self, monkeypatch, mock_postgresql_db):
+    def test_remove_primary_email_without_new_primary(self, mock_postgresql_db):
         """
         Test error when attempting to remove the primary email without specifying a new primary.
         """
@@ -272,7 +272,7 @@ class TestModifyAlternateEmails:
         assert response.status_code == 403
         assert "Cannot remove primary email" in response.json().get("detail", "")
 
-    def test_update_primary_email_not_found(self, monkeypatch, mock_postgresql_db):
+    def test_update_primary_email_not_found(self, mock_postgresql_db):
         """
         Test error when update for setting a new primary email fails.
         """


### PR DESCRIPTION
## Alternate email improvements

This pull request improves the alternate email endpoint by breaking the code into smaller functions that handle adding, removing, and changing alternate emails, as well as updating the primary email. The tests now check that the actual database changes happen, not just the status code. Also, the endpoint works in both development mode (with extra debugging details) and production mode (with a simple status response).

### Issues Fixed
* https://github.com/NickGuerrero/cti-sys/issues/23

### Tests

`TestModifyAlternateEmails` pytest class includes:
* 6 success tests (adding, removing, setting primary).
    * 3 production and 3 development.
* 6 failure tests (conflicting emails, removing primary, invalid primary).

To run tests locally:
```
pytest -v -k "TestModifyAlternateEmails"
```

<img width="1399" alt="Screenshot 2025-03-22 at 3 04 21 PM" src="https://github.com/user-attachments/assets/06db4751-11d6-4984-8244-d94a549552c8" />


On Github Actions:

```
pytest -v -m "not integration"
```

<img width="980" alt="Screenshot 2025-03-22 at 2 54 26 PM" src="https://github.com/user-attachments/assets/eacfba3e-8a7b-4f08-8b48-7bd6aad9e956" />
<img width="1282" alt="Screenshot 2025-03-22 at 2 54 48 PM" src="https://github.com/user-attachments/assets/1434e7fc-1645-460c-8323-934f36b2f903" />


### Notes on Library changes
* Additional Dependency
```
pydantic-settings==2.8.1
```
Added this package to handle settings and environment variables more easily.

### Checklist
- [x] I've reviewed the contribution guide
- [x] I've confirmed the changes work on my machine
- [x] This pull request is ready for review