### PR TITLE
Add Process Withdrawal Form Endpoint

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from src.applications.router import router as applications_router
 from src.students.alternate_emails.router import router as student_alternate_emails_router
+from src.students.process_withdrawal.router import router as process_withdrawal_router
 from src.students.attendance_log.router import router as student_attendence_log_router
 from src.students.accelerate.process_attendance.router import router as accelerate_attendance_record_router
 
@@ -33,4 +34,11 @@ api_router.include_router(
     accelerate_attendance_record_router,
     prefix="/students/accelerate/process-attendance",
     tags=["Accelerate"]
+)
+
+# /api/students/process-withdrawal/...
+api_router.include_router(
+    process_withdrawal_router,
+    prefix="/students/process-withdrawal",
+    tags=["Students"]
 )

--- a/src/database/mongo/core.py
+++ b/src/database/mongo/core.py
@@ -4,9 +4,12 @@ from pymongo.mongo_client import MongoClient
 from pymongo.server_api import ServerApi
 from bson import json_util
 
+from dotenv import load_dotenv  # added
+
 from src.config import MONGO_DATABASE_NAME
 from src.database.mongo.service import init_collections
 
+load_dotenv() # added
 MONGO_URL = environ.get("CTI_MONGO_URL")
 if not MONGO_URL:
     raise ValueError("MongoDB URL environment variable not found")

--- a/src/database/postgres/models.py
+++ b/src/database/postgres/models.py
@@ -151,3 +151,9 @@ class AccountabilityGroup(Base):
     group_name: Mapped[str] = mapped_column(String)
     student_accelerator: Mapped[str] = mapped_column(String)
     ag_students: Mapped[List["Accelerate"]] = relationship(back_populates="ag_record")
+
+class InactiveRequest(Base):
+    __tablename__ = "inactive_requests"
+    passkey: Mapped[int] = mapped_column(Integer, nullable=False, primary_key=True)
+    id: Mapped[int] = mapped_column(Integer, nullable=False)
+    created: Mapped[datetime] = mapped_column(DateTime, nullable=False)

--- a/src/students/process_withdrawal/router.py
+++ b/src/students/process_withdrawal/router.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.database.postgres.core import make_session
+from src.students.process_withdrawal.schemas import ProcessWithdrawalRequest 
+from src.students.process_withdrawal.service import process, fetch_inactive_record
+from src.config import settings
+
+router = APIRouter()
+
+@router.post("", status_code=status.HTTP_200_OK)
+def process_withdrawal(
+    request: ProcessWithdrawalRequest, 
+    db: Session = Depends(make_session),
+):
+    """
+    Endpoint to process responses form the withdrawal form.
+    Create a one-time passcode link to mark themselves inactive.
+    Store this record in the inactive_requests with a timestamp.
+    """
+    try: 
+        # Execute the email modification logic.
+        email = process(request=request, db=db)
+
+        # In production, return a basic status message.
+        if settings.app_env == "production":
+            return {"status": 200}
+        else: 
+            # In non production environments, return saved record from database
+            record = fetch_inactive_record(request.auto_email.lower(), db=db)
+            return {
+                "status": 200,
+                "id": record["id"],
+                "passkey": record["passkey"],
+                "timestamp": record["timestamp"],
+            }
+    
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")
+    except HTTPException as http_exc:
+        db.rollback()
+        raise http_exc
+    except Exception as e:
+        print("Error HERE: " + str(e))
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+    

--- a/src/students/process_withdrawal/schemas.py
+++ b/src/students/process_withdrawal/schemas.py
@@ -1,0 +1,7 @@
+from typing import List, Optional
+from pydantic import BaseModel, EmailStr
+
+class ProcessWithdrawalRequest(BaseModel):
+    auto_email: EmailStr
+    fname: str
+    lname: str

--- a/src/students/process_withdrawal/service.py
+++ b/src/students/process_withdrawal/service.py
@@ -1,0 +1,97 @@
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from src.database.postgres.models import StudentEmail, InactiveRequest
+from src.students.process_withdrawal.schemas import ProcessWithdrawalRequest
+from typing import List, Optional, Dict, Any
+import random
+import string
+from datetime import datetime, timedelta, timezone
+
+def process(*, request: ProcessWithdrawalRequest, db: Session) -> Dict[str, Any]:
+    """
+    Main entry point to process withdrawal request.
+    """
+    # Step 1:Check if auto_email or manual_email is primary_email 
+    google_form_email = request.auto_email
+    
+    # Query for primary email from auto_email
+    email_record = db.query(StudentEmail).filter(
+        func.lower(StudentEmail.email) == google_form_email
+    ).first()
+
+    if not email_record:
+        raise HTTPException(status_code=404, detail="Student not found")
+
+    # Retrieve the student's unique identifier.
+    cti_id = email_record.cti_id
+
+    # Query for all emails associated with this student.
+    all_emails = db.query(StudentEmail).filter(StudentEmail.cti_id == cti_id).all()
+
+    primary_email = None
+    # Build a list of emails and identify the primary email.
+    for e in all_emails:
+        if e.is_primary:
+            primary_email = e.email
+            break
+    
+    # Make sure google form email and primary email matches
+    if primary_email != google_form_email:
+        raise HTTPException(
+            status_code=403,
+            detail="Primary email must match the email used to submit the form."
+        )
+
+    # Step 2: Generate new link with a one-time password (OTP)
+    student_cti_id = cti_id
+    otp = int(''.join(random.choices(string.digits, k=16)) + str(student_cti_id)) # In future: come up with a more secure generation of OTP
+    create_timestamp = datetime.now(timezone.utc)
+    withdrawal_link = f"/api/students/{student_cti_id}/mark-inactive?key={otp}"
+    
+    # Step 3: Store withdrawal record and timestamp in inactive_requests  
+    new_inactive_record = InactiveRequest(
+        passkey=otp,
+        id=student_cti_id,
+        created=create_timestamp
+    )
+    db.add(new_inactive_record)
+    db.commit()
+
+    return withdrawal_link
+
+def fetch_inactive_record(google_form_email: str, db: Session) -> Dict[str, Any]:
+    """
+    Retrieve the withdrawal record associated with the student identified by the given Google Form email.
+
+    This function performs a case-insensitive search for the student's withdrawal record,
+    then fetches all associated emails—including the primary email—and returns them in a dictionary
+    for easy JSON conversion. It is primarily used for testing.
+    """
+    default_return = {"id": None, "passkey": None, "timestamp": None}
+    # fetch student id associated with google form email
+
+    email_record = db.query(StudentEmail).filter(
+        func.lower(StudentEmail.email) == google_form_email
+    ).first()
+
+    if not email_record:
+        return default_return
+
+    # Retrieve the student's unique identifier.
+    cti_id = email_record.cti_id
+
+    # Query for the withdrawal record using a case insensitive match.
+    withdrawal_record = db.query(InactiveRequest).filter(
+        func.lower(InactiveRequest.id) == cti_id
+    ).first()
+
+    if not withdrawal_record:
+        return default_return
+
+    return {
+        "id": withdrawal_record.id,
+        "passkey": withdrawal_record.passkey,
+        "timestamp": withdrawal_record.created
+    }

--- a/tests/students/alternate_emails/test_students_process_withdrawal_router.py
+++ b/tests/students/alternate_emails/test_students_process_withdrawal_router.py
@@ -1,0 +1,92 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from src.database.postgres.models import Student, StudentEmail, InactiveRequest
+from src.main import app
+from src.config import settings
+
+client = TestClient(app)
+
+class TestProcessWithdrawal:
+    # =========================
+    # Successful Withdrawal
+    # =========================
+
+    @pytest.mark.parametrize("env", ["production", "development"])
+    def test_process_withdrawal(self, env, monkeypatch, mock_postgresql_db):
+        """Test adding alternate emails for a student."""
+        monkeypatch.setattr(settings, "app_env", env)
+        primary_email = StudentEmail(email="primary@example.com", cti_id=1, is_primary=True)
+        manual_email = StudentEmail(email="manual@example.com", cti_id=1, is_primary=False)
+        record = InactiveRequest(passkey=2, id=1, created=3)
+
+        # Lookup and student record fetch.
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            primary_email,  # initial primary fetch in find_student_by_google_email
+            primary_email,
+            record
+        ]
+        # Simulate before and after modifications.
+        mock_postgresql_db.query.return_value.filter.return_value.all.side_effect = [
+            [primary_email, manual_email]
+        ]
+        query = mock_postgresql_db.query.return_value.filter.return_value
+        query.add.return_value = 1
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.rollback.return_value = None
+
+        response = client.post("/api/students/process-withdrawal", json={
+            "auto_email": primary_email.email,
+            "fname": "Jane",
+            "lname": "Doe"
+        })
+
+        assert response.status_code == 200
+        data = response.json()
+        if env == "production":
+            assert data == {"status": 200}
+        else:
+            assert data["status"] == 200
+            assert "id" in data
+            assert "passkey" in data
+            assert "timestamp" in data
+            assert data["id"] == record.id
+            assert data["passkey"] == record.passkey
+            assert data["timestamp"] == record.created
+        
+    # # ====================
+    # # Error Conditions
+    # # ====================
+    @pytest.mark.parametrize("env", ["production", "development"])
+    def test_process_withdrawal_mistmatch_email(self, env, monkeypatch, mock_postgresql_db):
+        """Test adding alternate emails for a student."""
+        monkeypatch.setattr(settings, "app_env", env)
+        student = Student(cti_id=1, fname="Jane", lname="Doe")
+        primary_email = StudentEmail(email="primary@example.com", cti_id=1, is_primary=True)
+        nonprimary_email = StudentEmail(email="manual@example.com", cti_id=1, is_primary=False)
+        record = InactiveRequest(passkey=2, id=1, created=3)
+
+        # Lookup and student record fetch.
+        mock_postgresql_db.query.return_value.filter.return_value.first.side_effect = [
+            nonprimary_email,  # initial primary fetch in find_student_by_google_email
+            primary_email,
+            record
+        ]
+        # Simulate before and after modifications.
+        mock_postgresql_db.query.return_value.filter.return_value.all.side_effect = [
+            [primary_email, nonprimary_email]
+        ]
+        query = mock_postgresql_db.query.return_value.filter.return_value
+        query.add.return_value = 1
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.rollback.return_value = None
+
+        response = client.post("/api/students/process-withdrawal", json={
+            "auto_email": nonprimary_email.email,
+            "fname": "Jane",
+            "lname": "Doe"
+        })
+
+        assert response.status_code == 403
+        detail = response.json().get("detail", "")
+        assert "Primary email must match the email used to submit the form." in detail


### PR DESCRIPTION
## Add Process Withdrawal Form Endpoint

This pull request adds an endpoint that processes a withdrawal request (which is assumed to come from a student's submission of the withdrawal form). The endpoint generates a unique passkey and a timestamp, then stores them along with the student's record in the InactiveRequest table. It also generates a link that the student can click on to manually deactivate their CTI account. If the student does not click on the link, their account will not be deactivated. 

A few to-dos for this endpoint:
* Should change Student.active field from True to False (or should this be updated in Student Self-Inactivate endpoint)
* There's no mechanism to send the link generated by this endpoint to the student yet 
* Endpoint Student Self-Inactivate is closely related and should be implemented after this endpoint is approved

### Issues Fixed
* [https://github.com/NickGuerrero/cti-sys/issues/14](https://github.com/NickGuerrero/cti-sys/issues/14)

### Tests
`TestProcessWithdrawal` pytest class includes 2 test cases (each test case tests 2 environments: prod and dev)
* Processes a valid request for an existing student using the student's primary email
* Processes an invalid request for an existing student but does not use the student's primary email

To run tests locally:
```
pytest -v -k "TestProcessWithdrawal"
```

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/f2316709-6df5-41d9-9317-109b7c9d01be" />

### Checklist
- [X] I've reviewed the contribution guide
- [X] I've confirmed the changes work on my machine
- [X] This pull request is ready for review