### PR TITLE
Update configuration and modify the quiz link (WIP)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,19 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      CTI_POSTGRES_URL: ${{ secrets.CTI_POSTGRES_URL }}
+      CTI_MONGO_URL: ${{ secrets.CTI_MONGO_URL }}
+      CTI_ACCESS_TOKEN: ${{ secrets.CTI_ACCESS_TOKEN }}
+      APP_ENV: ${{ secrets.APP_ENV }}
+      COURSE_ID_UNTERVIEW: ${{ secrets.COURSE_ID_UNTERVIEW }}
+      UNTERVIEW_SIS_COURSE_ID: ${{ secrets.UNTERVIEW_SIS_COURSE_ID }}
+      CUR_UNTERVIEW_SIS_SECTION_ID: ${{ secrets.CUR_UNTERVIEW_SIS_SECTION_ID }}
+      CUR_UNTERVIEW_SECTION_ID: ${{ secrets.CUR_UNTERVIEW_SECTION_ID }}
+      COURSE_ID_101: ${{ secrets.COURSE_ID_101 }}
+      COMMITMENT_QUIZ_ID: ${{ secrets.COMMITMENT_QUIZ_ID }}
+      SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+      SENDGRID_SENDER: ${{ secrets.SENDGRID_SENDER }}
 
     steps:
     - uses: actions/checkout@v2
@@ -18,14 +31,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-
-    - name: Set environment variables
-      env:
-        CTI_POSTGRES_URL: ${{ secrets.CTI_POSTGRES_URL }}
-        CTI_MONGO_URL: ${{ secrets.CTI_MONGO_URL }}
-      run: | 
-        echo "CTI_POSTGRES_URL=${{ secrets.CTI_POSTGRES_URL }}" >> $GITHUB_ENV
-        echo "CTI_MONGO_URL=${{ secrets.CTI_MONGO_URL }}" >> $GITHUB_ENV
 
     - name: Set PYTHONPATH
       run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ mongomock==4.3.0
 pydantic-settings==2.8.1
 requests==2.32.3
 pandas==2.2.3
+sendgrid==6.12.4

--- a/src/api.py
+++ b/src/api.py
@@ -4,7 +4,7 @@ from src.applications.router import router as applications_router
 from src.applications.canvas_export.router import router as canvas_export_router
 from src.applications.master_roster.router import router as applications_add_to_master_roster_router
 from src.students.alternate_emails.router import router as student_alternate_emails_router
-from src.students.attendance_log.router import router as student_attendence_log_router
+from src.students.attendance_log.router import router as student_attendance_log_router
 from src.students.accelerate.process_attendance.router import router as accelerate_attendance_record_router
 from src.students.missing_students.router import router as student_recover_attendance_router
 
@@ -41,7 +41,7 @@ api_router.include_router(
 
 # /api/students/process-attendance-log...
 api_router.include_router(
-    student_attendence_log_router,
+    student_attendance_log_router,
     prefix="/students/process-attendance-log",
     tags=["Students"]
 )

--- a/src/applications/master_roster/schemas.py
+++ b/src/applications/master_roster/schemas.py
@@ -26,17 +26,17 @@ class QuizSubmission(BaseModel):
     user_id: int
     submission_id: Optional[int]
     started_at: datetime
-    finished_at: datetime
+    finished_at: Optional[datetime]
     end_at: Optional[datetime]
     attempt: int
     extra_attempts: Optional[int]
     extra_time: Optional[int]
     manually_unlocked: Optional[bool]
-    time_spent: int
-    score: float
+    time_spent: Optional[int]
+    score: Optional[float]
     score_before_regrade: Optional[float]
-    kept_score: float
+    kept_score: Optional[float]
     fudge_points: Optional[float]
-    has_seen_results: bool
+    has_seen_results: Optional[bool]
     workflow_state: QuizSubmissionWorkflowState
     overdue_and_needs_submission: bool

--- a/src/applications/master_roster/service.py
+++ b/src/applications/master_roster/service.py
@@ -101,7 +101,7 @@ def get_all_quiz_submissions() -> set[int]:
 
     Uses multiple external requests through pagination to fetch all submissions.
     """
-    url = f"{settings.canvas_api_url}/api/v1/courses/{settings.course_id_101}/quizzes/{settings.commitment_quiz_id}/submissions?per_page=100"
+    url = f"{settings.canvas_api_url}/api/v1/courses/{settings.unterview_course_id}/quizzes/{settings.commitment_quiz_id}/submissions?per_page=100"
     headers = {
         "Authorization": f"Bearer {get_canvas_access_token()}",
     }

--- a/src/config.py
+++ b/src/config.py
@@ -1,18 +1,19 @@
 import os
+from dotenv import load_dotenv
 from pydantic_settings import BaseSettings
 
-# Consider moving into a pydantic-settings package's `class Settings(BaseSettings)` for environment-specific overrides
+load_dotenv()
 
 class Settings(BaseSettings):
     # NOTE SIS section ids need to be manually defined in Canvas
     # Go to Settings -> Sections -> Your Section -> Set SIS ID
     app_env: str = os.getenv("APP_ENV")
-    unterview_course_id: int = os.getenv("COURSE_ID_UNTERVIEW")
+    unterview_course_id: int = int(os.getenv("COURSE_ID_UNTERVIEW"))
     unterview_sis_course_id: str = os.getenv("UNTERVIEW_SIS_COURSE_ID")
     current_unterview_sis_section_id: str = os.getenv("CUR_UNTERVIEW_SIS_SECTION_ID")
-    current_unterview_section_id: int = os.getenv("CUR_UNTERVIEW_SECTION_ID")
-    course_id_101: int = os.getenv("COURSE_ID_101")
-    commitment_quiz_id: int = os.getenv("COMMITMENT_QUIZ_ID")
+    current_unterview_section_id: int = int(os.getenv("CUR_UNTERVIEW_SECTION_ID"))
+    course_id_101: int = int(os.getenv("COURSE_ID_101"))
+    commitment_quiz_id: int = int(os.getenv("COMMITMENT_QUIZ_ID"))
     canvas_api_url: str = "https://cti-courses.test.instructure.com"
     canvas_api_test_url: str = "https://cti-courses.test.instructure.com"
 

--- a/src/config.py
+++ b/src/config.py
@@ -7,11 +7,11 @@ class Settings(BaseSettings):
     # NOTE SIS section ids need to be manually defined in Canvas
     # Go to Settings -> Sections -> Your Section -> Set SIS ID
     app_env: str = os.getenv("APP_ENV")
-    unterview_course_id: int = os.getenv("UNTERVIEW_COURSE_ID")
+    unterview_course_id: int = os.getenv("COURSE_ID_UNTERVIEW")
     unterview_sis_course_id: str = os.getenv("UNTERVIEW_SIS_COURSE_ID")
     current_unterview_sis_section_id: str = os.getenv("CUR_UNTERVIEW_SIS_SECTION_ID")
     current_unterview_section_id: int = os.getenv("CUR_UNTERVIEW_SECTION_ID")
-    course_id_101: int = os.getenv("101_COURSE_ID")
+    course_id_101: int = os.getenv("COURSE_ID_101")
     commitment_quiz_id: int = os.getenv("COMMITMENT_QUIZ_ID")
     canvas_api_url: str = "https://cti-courses.test.instructure.com"
     canvas_api_test_url: str = "https://cti-courses.test.instructure.com"

--- a/src/config.py
+++ b/src/config.py
@@ -8,12 +8,12 @@ class Settings(BaseSettings):
     # NOTE SIS section ids need to be manually defined in Canvas
     # Go to Settings -> Sections -> Your Section -> Set SIS ID
     app_env: str = os.getenv("APP_ENV")
-    unterview_course_id: int = int(os.getenv("COURSE_ID_UNTERVIEW"))
+    unterview_course_id: int = os.getenv("COURSE_ID_UNTERVIEW")
     unterview_sis_course_id: str = os.getenv("UNTERVIEW_SIS_COURSE_ID")
     current_unterview_sis_section_id: str = os.getenv("CUR_UNTERVIEW_SIS_SECTION_ID")
-    current_unterview_section_id: int = int(os.getenv("CUR_UNTERVIEW_SECTION_ID"))
-    course_id_101: int = int(os.getenv("COURSE_ID_101"))
-    commitment_quiz_id: int = int(os.getenv("COMMITMENT_QUIZ_ID"))
+    current_unterview_section_id: int = os.getenv("CUR_UNTERVIEW_SECTION_ID")
+    course_id_101: int = os.getenv("COURSE_ID_101")
+    commitment_quiz_id: int = os.getenv("COMMITMENT_QUIZ_ID")
     canvas_api_url: str = "https://cti-courses.test.instructure.com"
     canvas_api_test_url: str = "https://cti-courses.test.instructure.com"
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,15 +1,18 @@
+import os
 from pydantic_settings import BaseSettings
 
 # Consider moving into a pydantic-settings package's `class Settings(BaseSettings)` for environment-specific overrides
 
 class Settings(BaseSettings):
-    app_env: str = "development"
-    unterview_course_id: int = 161
-    unterview_sis_course_id: str = "S161"
-    current_unterview_sis_section_id: str = "S194" # NOTE had to manually define this in Canvas
-    current_unterview_section_id: int = 194
-    course_id_101: int = 170
-    commitment_quiz_id: int = 2488
+    # NOTE SIS section ids need to be manually defined in Canvas
+    # Go to Settings -> Sections -> Your Section -> Set SIS ID
+    app_env: str = os.getenv("APP_ENV")
+    unterview_course_id: int = os.getenv("UNTERVIEW_COURSE_ID")
+    unterview_sis_course_id: str = os.getenv("UNTERVIEW_SIS_COURSE_ID")
+    current_unterview_sis_section_id: str = os.getenv("CUR_UNTERVIEW_SIS_SECTION_ID")
+    current_unterview_section_id: int = os.getenv("CUR_UNTERVIEW_SECTION_ID")
+    course_id_101: int = os.getenv("101_COURSE_ID")
+    commitment_quiz_id: int = os.getenv("COMMITMENT_QUIZ_ID")
     canvas_api_url: str = "https://cti-courses.test.instructure.com"
     canvas_api_test_url: str = "https://cti-courses.test.instructure.com"
 

--- a/src/students/alternate_emails/router.py
+++ b/src/students/alternate_emails/router.py
@@ -1,46 +1,204 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
+# src/students/alternate_emails/router.py
+
+from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from typing import List, Optional
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from src.database.postgres.core import make_session
 from src.students.alternate_emails.schemas import AlternateEmailRequest
 from src.students.alternate_emails.service import modify, fetch_current_emails
 from src.config import settings
+from src.utils.email import send_email as raw_send_email
 
 router = APIRouter()
+
+def send_email_notification(
+    to_email: str, 
+    subject: str, 
+    html_body: str
+) -> None:
+    """
+    Wrap the real send_email so background-task failures never bubble up.
+    This is used to send email notifications for alternate email changes.
+    """
+    try:
+        raw_send_email(to_email, subject, html_body)
+    except Exception:
+        pass
+
+def schedule_removal_notifications(
+    background_tasks: BackgroundTasks,
+    google_email: str,
+    removed_emails: List[str]
+) -> None:
+    if not removed_emails:
+        return
+    removed_lower = [e.strip().lower() for e in removed_emails]
+    html_list = ", ".join(removed_lower)
+    background_tasks.add_task(
+        send_email_notification,
+        google_email,
+        "Alternate email(s) removed",
+        f"<p>You've removed the following alternate email(s): <b>{html_list}</b>.</p>"
+    )
+
+def schedule_alternate_notifications(
+    background_tasks: BackgroundTasks,
+    google_email: str,
+    alt_emails: List[str]
+) -> None:
+    if not alt_emails:
+        return
+    alt_lower = [e.strip().lower() for e in alt_emails]
+    html_list = ", ".join(alt_lower)
+    background_tasks.add_task(
+        send_email_notification,
+        google_email,
+        "New alternate email(s) added",
+        f"<p>You've just added these alternate email(s): <b>{html_list}</b>.</p>"
+    )
+
+def schedule_primary_notifications(
+    background_tasks: BackgroundTasks,
+    old_primary: Optional[str],
+    new_primary: Optional[str]
+) -> None:
+    if not new_primary:
+        return
+    if old_primary and old_primary != new_primary:
+        background_tasks.add_task(
+            send_email_notification,
+            old_primary,
+            "Your primary email was changed",
+            f"<p>Your previous primary email ({old_primary}) was changed to {new_primary}.</p>"
+        )
+    background_tasks.add_task(
+        send_email_notification,
+        new_primary,
+        "New primary email confirmed",
+        f"<p>Your new primary email ({new_primary}) was confirmed.</p>"
+    )
+
+def schedule_combined_notifications(
+    background_tasks: BackgroundTasks,
+    google_email: str,
+    removed_emails: List[str],
+    alt_emails: List[str],
+    old_primary: Optional[str],
+    new_primary: Optional[str],
+) -> None:
+    """
+    Schedule a single email summarizing all changes made to alternate emails.
+    This combines removals, additions, and primary email changes into one message.
+    """
+    parts: List[str] = []
+
+    if removed_emails:
+        removed = ", ".join(e.strip().lower() for e in removed_emails)
+        parts.append(f"You've removed these alternate email(s): <b>{removed}</b>")
+
+    if alt_emails:
+        added = ", ".join(e.strip().lower() for e in alt_emails)
+        parts.append(f"You've added these alternate email(s): <b>{added}</b>")
+
+    if new_primary:
+        # summary line for everyone
+        if old_primary and old_primary != new_primary:
+            parts.append(f"Your primary address was changed from <b>{old_primary}</b> to <b>{new_primary}</b>")
+        parts.append(f"Your new primary email <b>{new_primary}</b> has been confirmed")
+
+    if parts:
+        html_summary = f"""
+        <html>
+          <body style="font-family:Arial,sans-serif;line-height:1.5;">
+            <p>Hi there,</p>
+            <p>Here's a summary of your email updates:</p>
+            <ul>
+              {''.join(f'<li>{line}</li>' for line in parts)}
+            </ul>
+            <p>If you have any questions, contact support.</p>
+            <p>Best,<br/>The CTI Team</p>
+          </body>
+        </html>
+        """
+        # send one combined email to the user who submitted the form
+        background_tasks.add_task(
+            send_email_notification,
+            google_email,
+            "Email address updates",
+            html_summary
+        )
+
+    # send a dedicated message to the old primary email if it changed
+    if new_primary and old_primary and old_primary != new_primary:
+        html_old = f"""
+        <html>
+          <body style="font-family:Arial,sans-serif;line-height:1.5;">
+            <p>Hi there,</p>
+            <p>Your previous primary email <b>{old_primary}</b> was just changed to <b>{new_primary}</b>.</p>
+            <p>If that wasn't you, please contact support immediately.</p>
+            <p>Best,<br/>The CTI Team</p>
+          </body>
+        </html>
+        """
+        background_tasks.add_task(
+            send_email_notification,
+            old_primary,
+            "Your primary email was changed",
+            html_old
+        )
+
 
 @router.post("", status_code=status.HTTP_200_OK)
 def modify_alternate_emails(
     request: AlternateEmailRequest,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(make_session),
 ):
     """
-    Endpoint to modify a student's alternate emails.
-    Processes the email modification request and returns a simple status for production,
-    or detailed email data for development and testing environments.
+    Modify a student's alternate and primary emails, then enqueue email notifications.
     """
     try:
-        # Execute the email modification logic.
+        # google_email = request.google_form_email.strip().lower()
+        # new_primary = request.primary_email.strip().lower() if request.primary_email else None
+        # old_primary = google_email
+
+        google_email = request.google_form_email.strip().lower()
+        pre_update = fetch_current_emails(google_email, db=db)
+        old_primary = pre_update["primary_email"]
+        new_primary = request.primary_email.strip().lower() if request.primary_email else None
+
         modify(request=request, db=db)
 
-        # In production, return a basic status message.
+        # Only one merged email per request
+        schedule_combined_notifications(
+            background_tasks,
+            google_email,
+            request.remove_emails,
+            request.alt_emails,
+            old_primary,
+            new_primary,
+        )
+
+        # Fetch updated data for the response
+        updated = fetch_current_emails(google_email, db=db)
+        current_primary = updated["primary_email"]
+
         if settings.app_env == "production":
             return {"status": 200}
-        else:
-            # In non production environments, return detailed email data.
-            updated = fetch_current_emails(request.google_form_email.lower(), db=db)
-            return {
-                "status": 200,
-                "emails": updated["emails"],
-                "primary_email": updated["primary_email"],
-            }
-    
+        return {
+            "status": 200,
+            "emails": updated["emails"],
+            "primary_email": current_primary,
+        }
+
     except SQLAlchemyError as e:
         db.rollback()
-        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")
-    except HTTPException as http_exc:
+        raise HTTPException(status_code=500, detail=f"Database error: {e}")
+    except HTTPException:
         db.rollback()
-        raise http_exc
+        raise
     except Exception as e:
         db.rollback()
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {e}")

--- a/src/students/alternate_emails/schemas.py
+++ b/src/students/alternate_emails/schemas.py
@@ -3,6 +3,6 @@ from pydantic import BaseModel, EmailStr
 
 class AlternateEmailRequest(BaseModel):
     alt_emails: List[EmailStr] = []
-    primary_email: Optional[str] = None
+    primary_email: Optional[str] = ""
     remove_emails: List[EmailStr] = []
     google_form_email: EmailStr

--- a/src/students/attendance_log/router.py
+++ b/src/students/attendance_log/router.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, BackgroundTasks
 from sqlalchemy.orm import Session
 
 from src.database.postgres.core import make_session
@@ -10,11 +10,14 @@ from src.students.attendance_log.service import process_attendance
 router = APIRouter()
 
 @router.post("", status_code=status.HTTP_200_OK)
-def process_attendance_log(db: Session = Depends(make_session)) -> Dict[str, Any]:
+def process_attendance_log(
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(make_session),
+) -> Dict[str, Any]:
     """
     Main endpoint: calls service logic to process attendance logs.
     We let the service handle errors on a per-row basis.
     Always return { status=200, sheets_processed, sheets_failed }.
     """
-    result = process_attendance(db)
+    result = process_attendance(db, background_tasks)
     return result

--- a/src/students/attendance_log/service.py
+++ b/src/students/attendance_log/service.py
@@ -7,13 +7,32 @@ from urllib.parse import urlparse, parse_qs
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 import io
-
+from fastapi import BackgroundTasks
+from src.config import settings
 from src.database.postgres.models import (
     Attendance, StudentEmail, MissingAttendance, StudentAttendance
 )
 from sqlalchemy.exc import SQLAlchemyError
+from src.utils.email import send_email as raw_send_email
 
-def process_attendance(db: Session) -> Dict[str, int]:
+def send_email_notification(
+    to_email: str, 
+    subject: str, 
+    html_body: str
+) -> None:
+    """
+    Wrap the real send_email so background-task failures never bubble up.
+    This is used to send email notifications for attendance processing.
+    """
+    try:
+        raw_send_email(to_email, subject, html_body)
+    except Exception:
+        pass
+
+def process_attendance(
+    db: Session,
+    background_tasks: BackgroundTasks,
+) -> Dict[str, int]:
     """
     Process unprocessed Attendance records with link_type='PearDeck':
     - Query all Attendance records where last_processed_date is None and link_type is 'PearDeck'.
@@ -23,38 +42,36 @@ def process_attendance(db: Session) -> Dict[str, int]:
         - On failure, rollback the transaction and increment sheets_failed.
     - Return a dictionary containing the counts of processed and failed sheets.
     """
-
-    # Query for unprocessed attendance records
     unprocessed = (
         db.query(Attendance)
-            .filter(Attendance.last_processed_date.is_(None))
-            .filter(func.lower(Attendance.link_type) == "peardeck")
-            .all()
+          .filter(Attendance.last_processed_date.is_(None))
+          .filter(func.lower(Attendance.link_type) == "peardeck")
+          .all()
     )
 
     sheets_processed = 0
     sheets_failed = 0
 
-    # Process each attendance record
-    # We use a try/except block to handle errors on a per-record basis
     for record in unprocessed:
         try:
-            process_attendance_record(record, db=db)
+            process_attendance_record(record, db=db, background_tasks=background_tasks)
             db.commit()
             sheets_processed += 1
         except (requests.RequestException, ValueError, SQLAlchemyError):
             db.rollback()
             sheets_failed += 1
 
-    # Return the result
-    # We don't raise an error here, we just return the counts
     return {
         "status": 200,
         "sheets_processed": sheets_processed,
         "sheets_failed": sheets_failed
     }
 
-def process_attendance_record(attendance_record: Attendance, db: Session) -> None:
+def process_attendance_record(
+    attendance_record: Attendance,
+    db: Session,
+    background_tasks: BackgroundTasks,
+) -> None:
     """
     Fetch the CSV data for this one Attendance record, parse each row, and
     update student_attendance or missing_attendance. If successful, mark last_processed_date.
@@ -62,50 +79,23 @@ def process_attendance_record(attendance_record: Attendance, db: Session) -> Non
     """
     df = fetch_csv_dataframe(attendance_record.link)
 
-    # Process each row in the DataFrame
-    # We use iterrows() to iterate over the DataFrame rows
     for _, row in df.iterrows():
         process_attendance_row(
             row_data=row,
             df_columns=df.columns,
             session_id=attendance_record.session_id,
-            db=db
+            db=db,
+            background_tasks=background_tasks,
         )
 
-    # Mark as processed
     attendance_record.last_processed_date = datetime.now()
-
-def fetch_csv_dataframe(link: str) -> pd.DataFrame:
-    """
-    Converts a Google Sheet link to a CSV export link, fetches CSV,
-    returns a pandas DataFrame. Checks for 'Name' and 'Email' columns.
-    Raises ValueError if missing columns or fetch fails.
-    """
-
-    # Fetch CSV from Google Sheets
-    csv_url = convert_google_sheet_link_to_csv(link)
-    resp = requests.get(csv_url)
-    resp.raise_for_status()
-
-    decoded_str = resp.content.decode("utf-8")
-
-    # Read CSV from string
-    df = pd.read_csv(io.StringIO(decoded_str))
-
-    # Clean up column names with extra spaces
-    df.columns = [col.strip() for col in df.columns]
-
-    # Check for required columns
-    if "Name" not in df.columns or "Email" not in df.columns:
-        raise ValueError("Required columns (Name, Email) not found in CSV.")
-
-    return df
 
 def process_attendance_row(
     row_data: pd.Series,
     df_columns: pd.Index,
     session_id: int,
-    db: Session
+    db: Session,
+    background_tasks: BackgroundTasks,
 ) -> None:
     """
     Processes a single row of attendance data:
@@ -156,6 +146,17 @@ def process_attendance_row(
             attended_minutes=attended_minutes
         )
         db.merge(missing)
+        background_tasks.add_task(
+            send_email_notification,
+            email,
+            "Attendance email not found - please update",
+            f"""
+            <p>Hi {name},</p>
+            <p>We couldn't find <strong>{email}</strong> in our records.</p>
+            <p>Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSe6KnTqeAi_VwAZ2yKl6-Zuu2w0Jedi9dr0KDRd2c6YKrfTjA/viewform">
+               click here</a> to submit your correct email address.</p>
+            """
+        )
     else:
         # Otherwise, update or insert the student's attendance
         cti_id = email_record.cti_id
@@ -180,6 +181,32 @@ def process_attendance_row(
                 session_score=session_score
             )
             db.add(new_attendance)
+
+def fetch_csv_dataframe(link: str) -> pd.DataFrame:
+    """
+    Converts a Google Sheet link to a CSV export link, fetches CSV,
+    returns a pandas DataFrame. Checks for 'Name' and 'Email' columns.
+    Raises ValueError if missing columns or fetch fails.
+    """
+
+    # Fetch CSV from Google Sheets
+    csv_url = convert_google_sheet_link_to_csv(link)
+    resp = requests.get(csv_url)
+    resp.raise_for_status()
+
+    decoded_str = resp.content.decode("utf-8")
+
+    # Read CSV from string
+    df = pd.read_csv(io.StringIO(decoded_str))
+
+    # Clean up column names with extra spaces
+    df.columns = [col.strip() for col in df.columns]
+
+    # Check for required columns
+    if "Name" not in df.columns or "Email" not in df.columns:
+        raise ValueError("Required columns (Name, Email) not found in CSV.")
+
+    return df
 
 def convert_google_sheet_link_to_csv(link: str) -> str:
     """
@@ -218,3 +245,4 @@ def convert_google_sheet_link_to_csv(link: str) -> str:
     # Construct the CSV export URL
     # Default gid is 0 if not found
     return f"https://docs.google.com/spreadsheets/d/{doc_id}/export?format=csv&gid={gid_value}"
+

--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -1,0 +1,16 @@
+import os
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+
+SENDGRID_API_KEY = os.getenv("SENDGRID_API_KEY")
+SENDER_EMAIL = os.getenv("SENDGRID_SENDER")
+
+def send_email(to_email: str, subject: str, html_content: str) -> None:
+    client = SendGridAPIClient(SENDGRID_API_KEY)
+    message = Mail(
+        from_email=SENDER_EMAIL,
+        to_emails=to_email,
+        subject=subject,
+        html_content=html_content,
+    )
+    client.send(message)


### PR DESCRIPTION
## Update configuration and modify the quiz link (WIP)

### Issues Being Addressed
* Update branch with changes from main (namely the email service)
* Moved config variables to env vars. The env set-up will need to be modified
* Changed the commitment quiz link from the 101 Post-Quiz to the Unterview Commitment Quiz (WIP)

### Tests
Notably, test_get_all_quiz_submissions_integration from test_applications_master_roster_service.py is the single test failing. 
```
fastapi.exceptions.HTTPException: 422: Invalid quiz submission data found: [
  {'type': 'datetime_type', 'loc': ('finished_at',), 'msg': 'Input should be a valid datetime', 'input': None, 'url': 'https://errors.pydantic.dev/2.10/v/datetime_type'},
  {'type': 'int_type', 'loc': ('time_spent',), 'msg': 'Input should be a valid integer', 'input': None, 'url': 'https://errors.pydantic.dev/2.10/v/int_type'},
  {'type': 'float_type', 'loc': ('score',), 'msg': 'Input should be a valid number', 'input': None, 'url': 'https://errors.pydantic.dev/2.10/v/float_type'}
]
```
All tests pass with the 101 Post-Quiz, but not with the Commitment Quiz. Based on the error message, it seems that the quiz submission object schema needs to be changed.

### Next Steps
There was a miscommunication on which quiz should be tested, so the endpoint should work for the current commitment quiz. Ideally, we're able to change this more easily in case we want to change commitment quiz processes in the future. I can take another look at resolving this issue, but I'm passing this back since you likely have more experience working with Pydantic and the quiz submission object in question. Sorry for the delay in the review.


### Checklist
- [X] I've reviewed the contribution guide
- [ ] I've confirmed the changes work on my machine
- [ ] This pull request is ready for review