### PR TITLE
Withdrawal Form Processing 

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -8,6 +8,8 @@ from src.students.attendance_log.router import router as student_attendance_log_
 from src.students.accelerate.process_attendance.router import router as accelerate_attendance_record_router
 from src.students.missing_students.router import router as student_recover_attendance_router
 from src.students.attendance_entry.router import router as student_attendance_entry_router
+from src.students.withdrawal_processing.router import router as student_withdrawal_router
+
 from src.gsheet.refresh.router import router as gsheet_refresh_router
 from src.utils.authorization import verify_api_key
 
@@ -66,6 +68,13 @@ api_router.include_router(
 api_router.include_router(
     student_attendance_entry_router,
     prefix="/students/create-attendance-entry",
+    tags=["Students"],
+)
+
+# /api/students/process-withdrawal
+api_router.include_router(
+    student_withdrawal_router,
+    prefix="/students/process-withdrawal",
     tags=["Students"],
 )
 

--- a/src/students/withdrawal_processing/router.py
+++ b/src/students/withdrawal_processing/router.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from src.database.postgres.core import make_session
+from src.students.withdrawal_processing.service import process_withdrawal_form
+from src.utils.exceptions import handle_db_exceptions
+
+router = APIRouter()
+
+@router.post("", status_code=status.HTTP_200_OK)
+def process_withdrawal(
+    email: str,
+    db: Session = Depends(make_session),
+) -> Dict[str, Any]:
+    """
+    Handle CTI Accelerate withdrawal submissions.
+
+    Receives the student's email from the form submission
+    and deactivates all related records (Student, Accelerate)
+    by setting 'active=False'.
+    """
+    try:
+        result = process_withdrawal_form(db, email)
+        db.commit()
+        return result
+    except Exception as exc:
+        handle_db_exceptions(db, exc)

--- a/src/students/withdrawal_processing/router.py
+++ b/src/students/withdrawal_processing/router.py
@@ -6,12 +6,13 @@ from sqlalchemy.orm import Session
 from src.database.postgres.core import make_session
 from src.students.withdrawal_processing.service import process_withdrawal_form
 from src.utils.exceptions import handle_db_exceptions
+from src.students.withdrawal_processing.schemas import WithdrawalRequest
 
 router = APIRouter()
 
 @router.post("", status_code=status.HTTP_200_OK)
 def process_withdrawal(
-    email: str,
+    request: WithdrawalRequest,
     db: Session = Depends(make_session),
 ) -> Dict[str, Any]:
     """
@@ -22,7 +23,7 @@ def process_withdrawal(
     by setting 'active=False'.
     """
     try:
-        result = process_withdrawal_form(db, email)
+        result = process_withdrawal_form(db, request.email)
         db.commit()
         return result
     except Exception as exc:

--- a/src/students/withdrawal_processing/schemas.py
+++ b/src/students/withdrawal_processing/schemas.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel, EmailStr
+
+class WithdrawalRequest(BaseModel):
+    email: EmailStr

--- a/src/students/withdrawal_processing/service.py
+++ b/src/students/withdrawal_processing/service.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+
+from src.database.postgres.models import Student, Accelerate, StudentEmail
+
+
+def process_withdrawal_form(db: Session, email: str) -> Dict[str, Any]:
+    """
+    Deactivates the student and all related records with an 'active' field.
+    For now, this includes Student and Accelerate records.
+    """
+    # Look up student via email
+    email_entry = db.execute(
+        select(StudentEmail).where(StudentEmail.email == email)
+    ).scalar_one_or_none()
+
+    if not email_entry:
+        return {"status": 404, "message": f"No student found with email: {email}"}
+
+    student = db.query(Student).filter(Student.cti_id == email_entry.cti_id).first()
+    if not student:
+        return {"status": 404, "message": f"No student record found for email: {email}"}
+
+    # Flip all active flags to False
+    student.active = False
+
+    if student.accelerate_record:
+        student.accelerate_record.active = False
+
+    db.flush()
+
+    return {
+        "status": 200,
+        "message": f"Student {student.fullname} (CTI ID: {student.cti_id}) and all related records have been deactivated.",
+        "email": email,
+    }

--- a/tests/students/withdrawal_processing/test_student_withdrawal_processing_router.py
+++ b/tests/students/withdrawal_processing/test_student_withdrawal_processing_router.py
@@ -1,5 +1,3 @@
-import pytest
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 from sqlalchemy.exc import SQLAlchemyError
 from src.students import withdrawal_processing as module
@@ -13,11 +11,10 @@ class TestProcessWithdrawal:
         monkeypatch.setattr(module.router, "process_withdrawal_form", lambda db, email: fake_result)
         mock_postgresql_db.commit = MagicMock()
 
-        response = client.post("/api/students/process-withdrawal", params={"email": "missing@example.com"})
+        response = client.post("/api/students/process-withdrawal", json={"email": "missing@example.com"})
         assert response.status_code == 200
         assert response.json() == fake_result
         mock_postgresql_db.commit.assert_called_once()
-
 
     def test_successful_deactivation(self, client, mock_postgresql_db, monkeypatch):
         """
@@ -36,12 +33,11 @@ class TestProcessWithdrawal:
         monkeypatch.setattr(module.router, "process_withdrawal_form", fake_service)
         mock_postgresql_db.commit = MagicMock()
 
-        response = client.post("/api/students/process-withdrawal", params={"email": "john.doe@example.com"})
+        response = client.post("/api/students/process-withdrawal", json={"email": "john.doe@example.com"})
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == 200
         assert "deactivated" in data["message"]
-
         mock_postgresql_db.commit.assert_called_once()
 
     def test_invalid_student_record(self, client, mock_postgresql_db, monkeypatch):
@@ -52,11 +48,10 @@ class TestProcessWithdrawal:
         monkeypatch.setattr(module.router, "process_withdrawal_form", lambda db, email: fake_result)
         mock_postgresql_db.commit = MagicMock()
 
-        response = client.post("/api/students/process-withdrawal", params={"email": "test@example.com"})
+        response = client.post("/api/students/process-withdrawal", json={"email": "test@example.com"})
         assert response.status_code == 200
         assert response.json() == fake_result
         mock_postgresql_db.commit.assert_called_once()
-
 
     def test_database_error_raises_500(self, client, mock_postgresql_db):
         """
@@ -65,6 +60,6 @@ class TestProcessWithdrawal:
         mock_postgresql_db.execute.side_effect = SQLAlchemyError("db failure")
         mock_postgresql_db.rollback = MagicMock()
 
-        response = client.post("/api/students/process-withdrawal", params={"email": "error@example.com"})
+        response = client.post("/api/students/process-withdrawal", json={"email": "error@example.com"})
         assert response.status_code == 500
         mock_postgresql_db.rollback.assert_called_once()

--- a/tests/students/withdrawal_processing/test_student_withdrawal_processing_router.py
+++ b/tests/students/withdrawal_processing/test_student_withdrawal_processing_router.py
@@ -1,0 +1,70 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from sqlalchemy.exc import SQLAlchemyError
+from src.students import withdrawal_processing as module
+
+class TestProcessWithdrawal:
+    def test_student_not_found(self, client, mock_postgresql_db, monkeypatch):
+        """
+        Simulate a scenario where the student email does not exist.
+        """
+        fake_result = {"status": 404, "message": "No student found with email: missing@example.com"}
+        monkeypatch.setattr(module.router, "process_withdrawal_form", lambda db, email: fake_result)
+        mock_postgresql_db.commit = MagicMock()
+
+        response = client.post("/api/students/process-withdrawal", params={"email": "missing@example.com"})
+        assert response.status_code == 200
+        assert response.json() == fake_result
+        mock_postgresql_db.commit.assert_called_once()
+
+
+    def test_successful_deactivation(self, client, mock_postgresql_db, monkeypatch):
+        """
+        Test a normal case where Student and Accelerate records are deactivated.
+        """
+        fake_result = {
+            "status": 200,
+            "message": "Student John Doe (CTI ID: 101) and all related records have been deactivated.",
+            "email": "john.doe@example.com",
+        }
+
+        def fake_service(db, email):
+            assert email == "john.doe@example.com"
+            return fake_result
+
+        monkeypatch.setattr(module.router, "process_withdrawal_form", fake_service)
+        mock_postgresql_db.commit = MagicMock()
+
+        response = client.post("/api/students/process-withdrawal", params={"email": "john.doe@example.com"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == 200
+        assert "deactivated" in data["message"]
+
+        mock_postgresql_db.commit.assert_called_once()
+
+    def test_invalid_student_record(self, client, mock_postgresql_db, monkeypatch):
+        """
+        Test when the email exists but no associated Student record is found.
+        """
+        fake_result = {"status": 404, "message": "No student record found for email: test@example.com"}
+        monkeypatch.setattr(module.router, "process_withdrawal_form", lambda db, email: fake_result)
+        mock_postgresql_db.commit = MagicMock()
+
+        response = client.post("/api/students/process-withdrawal", params={"email": "test@example.com"})
+        assert response.status_code == 200
+        assert response.json() == fake_result
+        mock_postgresql_db.commit.assert_called_once()
+
+
+    def test_database_error_raises_500(self, client, mock_postgresql_db):
+        """
+        Simulate a database error during the withdrawal process.
+        """
+        mock_postgresql_db.execute.side_effect = SQLAlchemyError("db failure")
+        mock_postgresql_db.rollback = MagicMock()
+
+        response = client.post("/api/students/process-withdrawal", params={"email": "error@example.com"})
+        assert response.status_code == 500
+        mock_postgresql_db.rollback.assert_called_once()


### PR DESCRIPTION
## Withdrawal Form Processing 

This PR adds a new endpoint to handle CTI Accelerate withdrawal submissions by deactivating student records. The endpoint sets `active=False` for the corresponding `Student` and `Accelerate` records based on the provided email. 

### Issues Fixed
* https://github.com/NickGuerrero/cti-sys/issues/14

### Tests
`TestProcessWithdrawal` pytest includes 4 total tests:
* Successful student deactivation  
* Handling of missing or invalid emails  
* Correct response formatting and status codes
#### To run tests locally:
```
pytest -v -k "TestProcessWithdrawal"
```

<img width="1366" height="274" alt="Screenshot 2025-10-30 at 4 13 59 PM" src="https://github.com/user-attachments/assets/b4359b0b-d58e-4556-8a40-6a76f6ad9bb0" />

#### On Github Actions:
```
pytest -v -m "not integration"
```
<img width="1251" height="93" alt="Screenshot 2025-10-30 at 4 38 05 PM" src="https://github.com/user-attachments/assets/99729071-b341-461d-a56f-90c7e51f4d3f" />


### Checklist
- [x] I've reviewed the contribution guide
- [x] I've confirmed the changes work on my machine
- [x] This pull request is ready for review