### PR TITLE
Update process attendance logic to use gspread instead of CSV export

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,22 @@ from src.database.mongo.core import get_mongo
 from src.database.mongo.service import init_collections
 from src.database.postgres.core import make_session
 from src.main import app
+import gspread
+
+@pytest.fixture(scope="function")
+def mock_gspread(monkeypatch):
+    """
+    Fixture to mock gspread authentication.
+    This overrides both production and development credential paths.
+    """
+    mock_gc = MagicMock(spec=gspread.Client)
+    
+    # Mock the production path
+    monkeypatch.setattr("src.gsheet.utils.create_credentials", lambda: mock_gc)
+    # Mock the development path
+    monkeypatch.setattr("gspread.service_account", lambda filename: mock_gc)
+    
+    return mock_gc
 
 # Fixtures for tests
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Gspread update

Updated attendance logic to use gspread to read Google Sheets data directly as a pandas DataFrame instead of CSV export URL construction with GID value. 

### Issues Fixed
* Attendance entry links no longer require a GID value, it automatically finds the correct worksheet tab
* Eliminated dependency on CSV export URL construction
* Works with publicly viewable Google Sheets

### Tests
`TestProcessAttendanceLog` pytest class includes 13 total test cases:

- Updated all test cases to use `mock_gspread` fixture
- Uses mocked gspread to read data instead of CSV export URL construction
- Parameterized full attendance logic test

To run tests locally:

```
pytest -v -k "TestProcessAttendanceLog"
```
<img width="1380" height="497" alt="Screenshot 2025-11-19 at 1 55 27 PM" src="https://github.com/user-attachments/assets/6b742ac2-3b7a-43e5-a2fc-433e7613321c" />

### Checklist
- [x] I've reviewed the contribution guide
- [x] I've confirmed the changes work on my machine
- [x] This pull request is ready for review