### PR TITLE
Check Actvity

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -29,7 +29,7 @@ DB_URLS = {
 
 def get_url() -> str:
     # Alembic Command line: alembic -x environment=development
-    env_name = config.get_main_option("environment") or "development"
+    env_name = context.get_x_argument(as_dictionary=True).get("environment") or "development"
     url = DB_URLS.get(env_name)
     if not url:
         raise RuntimeError(f"No database URL configured for environment '{env_name}'")

--- a/migrations/versions/ab2e5d7e05e8_add_last_canvas_access.py
+++ b/migrations/versions/ab2e5d7e05e8_add_last_canvas_access.py
@@ -22,10 +22,11 @@ def upgrade() -> None:
     # Add last_canvas_access column to accelerate_course_progress
     op.add_column(
         'accelerate_course_progress',
-        sa.Column('last_canvas_access', sa.DateTime(timezone=True), nullable=True)
+        sa.Column('last_canvas_access', sa.DateTime(timezone=False), nullable=True)
     )
 
 
 def downgrade() -> None:
     # Drop column
     op.drop_column('accelerate_course_progress', 'last_canvas_access')
+    

--- a/migrations/versions/ab2e5d7e05e8_add_last_canvas_access.py
+++ b/migrations/versions/ab2e5d7e05e8_add_last_canvas_access.py
@@ -1,0 +1,31 @@
+"""Add last_canvas_access
+
+Revision ID: ab2e5d7e05e8
+Revises: c0025f85a371
+Create Date: 2025-12-04 11:24:44.987577
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ab2e5d7e05e8'
+down_revision: Union[str, None] = 'c0025f85a371'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add last_canvas_access column to accelerate_course_progress
+    op.add_column(
+        'accelerate_course_progress',
+        sa.Column('last_canvas_access', sa.DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    # Drop column
+    op.drop_column('accelerate_course_progress', 'last_canvas_access')

--- a/src/api.py
+++ b/src/api.py
@@ -6,6 +6,7 @@ from src.applications.master_roster.router import router as applications_add_to_
 from src.students.alternate_emails.router import router as student_alternate_emails_router
 from src.students.attendance_log.router import router as student_attendance_log_router
 from src.students.accelerate.process_attendance.router import router as accelerate_attendance_record_router
+from src.students.accelerate.check_activity.router import router as accelerate_activity_check_router
 from src.students.missing_students.router import router as student_recover_attendance_router
 from src.students.attendance_entry.router import router as student_attendance_entry_router
 from src.gsheet.refresh.router import router as gsheet_refresh_router
@@ -52,6 +53,13 @@ api_router.include_router(
 api_router.include_router(
     accelerate_attendance_record_router,
     prefix="/students/accelerate/process-attendance",
+    tags=["Accelerate"],
+)
+
+# /api/students/accelerate/check-activity
+api_router.include_router(
+    accelerate_activity_check_router,
+    prefix="/students/accelerate/check-activity",
     tags=["Accelerate"],
 )
 

--- a/src/config.py
+++ b/src/config.py
@@ -52,6 +52,10 @@ class Settings(BaseSettings):
     sa_whitelist: str = "SA Whitelist"
     gsheet_write_rows_max: int = 998
 
+    # Thresholds in weeks for determining if a student is active
+    activity_attendance_threshold_weeks: int = Field(default=2, description="Number of weeks to check for attendance activity")
+    activity_canvas_threshold_weeks: int = Field(default=2, description="Number of weeks to check for Canvas activity")
+    
 settings = Settings()
 
 # TODO: Move these into the settings object properly

--- a/src/config.py
+++ b/src/config.py
@@ -46,16 +46,20 @@ class Settings(BaseSettings):
     gs_private_key_id: Optional[str] = Field(validation_alias="GS_PRIVATE_KEY_ID", default=None)
     gs_project_id: Optional[str] = Field(validation_alias="GS_PROJECT_ID", default=None)
 
+    # Thresholds in weeks for determining if a student is active
+    activity_attendance_threshold_weeks: int = Field(validation_alias="ACTIVITY_ATTENDANCE_THRESHOLD_WEEKS",
+                                                     default=2,
+                                                     description="Number of weeks to check for attendance activity")
+    activity_canvas_threshold_weeks: int = Field(validation_alias="ACTIVITY_CANVAS_THRESHOLD_WEEKS",
+                                                 default=2,
+                                                 description="Number of weeks to check for Canvas activity")
+
     # Application Constants
     canvas_api_url: str = "https://cti-courses.instructure.com"
     canvas_api_test_url: str = "https://cti-courses.test.instructure.com"
     sa_whitelist: str = "SA Whitelist"
     gsheet_write_rows_max: int = 998
 
-    # Thresholds in weeks for determining if a student is active
-    activity_attendance_threshold_weeks: int = Field(default=2, description="Number of weeks to check for attendance activity")
-    activity_canvas_threshold_weeks: int = Field(default=2, description="Number of weeks to check for Canvas activity")
-    
 settings = Settings()
 
 # TODO: Move these into the settings object properly

--- a/src/database/postgres/models.py
+++ b/src/database/postgres/models.py
@@ -171,6 +171,7 @@ class AccelerateCourseProgress(Base):
     latest_milestone: Mapped[Optional[str]] = mapped_column(String)
     pathway_score: Mapped[Optional[float]] = mapped_column(Float(3))
     pathway_difference: Mapped[Optional[int]] = mapped_column(Integer)
+    last_canvas_access: Mapped[Optional[datetime]] = mapped_column(DateTime)
     owner: Mapped["Accelerate"] = relationship(back_populates="progress_record")
 
 class AccountabilityGroup(Base):

--- a/src/students/accelerate/check_activity/router.py
+++ b/src/students/accelerate/check_activity/router.py
@@ -12,14 +12,12 @@ router = APIRouter()
 
 @router.post("", status_code=status.HTTP_200_OK)
 def check_all_students_activity(
-    attendance_threshold_weeks: Optional[int] = Query(None, ge=1),
-    canvas_threshold_weeks: Optional[int] = Query(None, ge=1),
     db: Session = Depends(make_session),
 ) -> Dict[str, Any]:
     """Check and update activity for all active Accelerate students."""
     try:
-        att_threshold = attendance_threshold_weeks or settings.activity_attendance_threshold_weeks
-        canvas_threshold = canvas_threshold_weeks or settings.activity_canvas_threshold_weeks
+        att_threshold = settings.activity_attendance_threshold_weeks
+        canvas_threshold = settings.activity_canvas_threshold_weeks
         
         results = service.check_all_students(db, att_threshold, canvas_threshold)
         

--- a/src/students/accelerate/check_activity/router.py
+++ b/src/students/accelerate/check_activity/router.py
@@ -1,0 +1,32 @@
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.orm import Session
+
+from src.config import settings
+from src.database.postgres.core import make_session
+from src.utils.exceptions import handle_db_exceptions
+import src.students.accelerate.check_activity.service as service
+
+router = APIRouter()
+
+@router.post("", status_code=status.HTTP_200_OK)
+def check_all_students_activity(
+    attendance_threshold_weeks: Optional[int] = Query(None, ge=1),
+    canvas_threshold_weeks: Optional[int] = Query(None, ge=1),
+    db: Session = Depends(make_session),
+) -> Dict[str, Any]:
+    """Check and update activity for all active Accelerate students."""
+    try:
+        att_threshold = attendance_threshold_weeks or settings.activity_attendance_threshold_weeks
+        canvas_threshold = canvas_threshold_weeks or settings.activity_canvas_threshold_weeks
+        
+        results = service.check_all_students(db, att_threshold, canvas_threshold)
+        
+        if settings.app_env == "production":
+            results.pop("details", None)
+        
+        return results
+        
+    except Exception as exc:
+        handle_db_exceptions(db, exc)

--- a/src/students/accelerate/check_activity/service.py
+++ b/src/students/accelerate/check_activity/service.py
@@ -1,0 +1,210 @@
+import requests
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional, Tuple
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+import pytz
+
+from src.database.postgres.models import StudentEmail
+from src.config import settings
+from src.database.postgres.models import (
+    Student, Accelerate, AccelerateCourseProgress, 
+    CanvasID, StudentAttendance, Attendance
+)
+
+
+def get_current_pacific_time() -> datetime:
+    """Get current time in Pacific timezone as naive datetime."""
+    pacific_time_zone = pytz.timezone('America/Los_Angeles')
+    return datetime.now(pacific_time_zone).replace(tzinfo=None)
+
+
+def fetch_canvas_last_login(canvas_id: int) -> Optional[datetime]:
+    """Fetch last_login timestamp from Canvas API and convert to Pacific time."""
+    if not settings.cti_access_token:
+        raise ValueError("Missing Canvas API configuration (CTI_ACCESS_TOKEN)")
+    
+    url = f"{settings.canvas_api_test_url}/api/v1/users/{canvas_id}"
+    
+    response = requests.get(
+        url,
+        params={"include[]": "last_login"},
+        headers={"Authorization": f"Bearer {settings.cti_access_token}"},
+        timeout=10,
+    )
+    
+    if response.status_code == 404:
+        return None
+    
+    if response.status_code == 401:
+        raise ValueError(
+            "Please check that CTI_ACCESS_TOKEN is set correctly and has not expired."
+        )
+        
+    response.raise_for_status()
+    user_data = response.json()
+    
+    last_login_raw = user_data.get("last_login")
+    if not last_login_raw:
+        return None
+    
+    # Parse UTC datetime from Canvas and convert to Pacific time
+    last_login_utc = datetime.fromisoformat(last_login_raw.replace("Z", "+00:00"))
+    pacific_time_zone = pytz.timezone('America/Los_Angeles')
+    last_login_pacific = last_login_utc.astimezone(pacific_time_zone)
+    
+    return last_login_pacific.replace(tzinfo=None)
+
+
+def check_attendance(db: Session, cti_id: int, threshold_weeks: int) -> bool:
+    """Check if a student has attended any Accelerate session within the threshold period."""
+    now = get_current_pacific_time()
+    check_start_date = now - timedelta(days=threshold_weeks * 7)
+    
+    attendance_exists = db.query(StudentAttendance).join(
+        Attendance, StudentAttendance.session_id == Attendance.session_id
+    ).filter(
+        and_(
+            StudentAttendance.cti_id == cti_id,
+            Attendance.program == "Accelerate",
+            Attendance.session_start >= check_start_date
+        )
+    ).first()
+    
+    return attendance_exists is not None
+
+
+def check_canvas(db: Session, cti_id: int, threshold_weeks: int) -> Tuple[bool, Optional[datetime]]:
+    """Check if a student has accessed Canvas within the threshold period."""
+    canvas_record = db.query(CanvasID).filter(CanvasID.cti_id == cti_id).first()
+    if not canvas_record:
+        return False, None
+    
+    last_login = fetch_canvas_last_login(canvas_record.canvas_id)
+    if not last_login:
+        return False, None
+    
+    now = get_current_pacific_time()
+    check_start_date = now - timedelta(days=threshold_weeks * 7)
+    is_active = last_login >= check_start_date
+    
+    return is_active, last_login
+
+
+def update_activity_status(
+    db: Session,
+    cti_id: int,
+    is_active: bool,
+    last_canvas_access: Optional[datetime]
+) -> bool:
+    """Update the accelerate.active status and accelerate_course_progress record."""
+    accelerate_record = db.query(Accelerate).filter(Accelerate.cti_id == cti_id).first()
+    if not accelerate_record:
+        return False
+    
+    accelerate_record.active = is_active
+    
+    # Update or create progress record if we have Canvas access data
+    if last_canvas_access:
+        progress_record = db.query(AccelerateCourseProgress).filter(
+            AccelerateCourseProgress.cti_id == cti_id
+        ).first()
+
+        if progress_record:
+            progress_record.last_canvas_access = last_canvas_access
+        else:
+            progress_record = AccelerateCourseProgress(
+                cti_id=cti_id,
+                last_canvas_access=last_canvas_access
+            )
+            db.add(progress_record)
+    
+    return True
+
+
+def process_student_activity(
+    db: Session,
+    student: Student,
+    att_threshold: int,
+    canvas_threshold: int
+) -> Dict[str, Any]:
+    """Process a single student's activity check."""
+    cti_id = student.cti_id
+    
+    # Check both activity types
+    has_attendance_activity = check_attendance(db, cti_id, att_threshold)
+    has_canvas_activity, last_canvas_access = check_canvas(db, cti_id, canvas_threshold)
+    
+    # Student is active if they have either type of activity
+    is_active = has_attendance_activity or has_canvas_activity
+    
+    if not update_activity_status(db, cti_id, is_active, last_canvas_access):
+        return {
+            "cti_id": cti_id,
+            "error": "No Accelerate record found for this student"
+        }
+    
+    # Get student email
+    email_record = db.query(StudentEmail).filter(StudentEmail.cti_id == cti_id).first()
+    cti_email = email_record.email if email_record else None
+    
+    # Format last canvas access for JSON response
+    last_canvas_str = last_canvas_access.isoformat() if last_canvas_access else None
+    
+    return {
+        "cti_id": cti_id,
+        "email": cti_email,
+        "name": student.fullname,
+        "attendance_activity": has_attendance_activity,
+        "canvas_activity": has_canvas_activity,
+        "last_canvas_access": last_canvas_str,
+        "active": is_active,
+    }
+
+
+def check_all_students(
+    db: Session,
+    att_threshold: int,
+    canvas_threshold: int
+) -> Dict[str, Any]:
+    """
+    Check and update activity status for all active Accelerate students.
+    Commits changes per student to avoid long transactions.
+    """
+    active_students = db.query(Student).join(
+        Accelerate, Student.cti_id == Accelerate.cti_id
+    ).filter(
+        Student.active == True
+    ).all()
+    
+    results = {
+        "status": 200,
+        "students_processed": len(active_students),
+        "students_marked_active": 0,
+        "students_marked_inactive": 0,
+        "details": [],
+        "errors": [],
+    }
+    
+    for student in active_students:
+        try:
+            result = process_student_activity(db, student, att_threshold, canvas_threshold)
+            
+            if "error" in result:
+                results["errors"].append(result)
+                db.rollback()
+            else:
+                db.commit()
+                
+                if result["active"]:
+                    results["students_marked_active"] += 1
+                else:
+                    results["students_marked_inactive"] += 1
+                
+                results["details"].append(result)
+                
+        except Exception as e:
+            db.rollback()
+            results["errors"].append({"cti_id": student.cti_id, "error": str(e)})
+    
+    return results

--- a/tests/students/accelerate/check_activity/test_check_activity_router.py
+++ b/tests/students/accelerate/check_activity/test_check_activity_router.py
@@ -1,0 +1,427 @@
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+import pytz
+from src.database.postgres.models import AccelerateCourseProgress
+from src.students.accelerate.check_activity import service as svc
+
+class TestCheckAccelerateActivity:  
+      
+    def test_student_active_with_both_attendance_and_canvas(self, client, monkeypatch, mock_postgresql_db):
+        """Test student marked active when they have BOTH attendance and Canvas activity."""
+        # Create a mock student who is very engaged
+        student = MagicMock()
+        student.cti_id = 1001
+        student.fullname = "Super Active Student"
+        student.active = True
+        
+        # Mock the database query to return our test student
+        mock_query = MagicMock()
+        mock_query.join.return_value.filter.return_value.all.return_value = [student]
+        mock_postgresql_db.query.return_value = mock_query
+        
+        # Create mock Accelerate record that starts as INACTIVE
+        acc = MagicMock()
+        acc.cti_id = 1001
+        acc.active = False
+        
+        # Mock attendance check to return True - student HAS attended sessions
+        monkeypatch.setattr(svc, "check_attendance", lambda db, cti_id, threshold: True)
+        
+        # Mock Canvas activity check to also return True with a recent login
+        pacific_tz = pytz.timezone('America/Los_Angeles')
+        last_login = datetime.now(pacific_tz).replace(tzinfo=None) - timedelta(hours=3)
+        monkeypatch.setattr(svc, "check_canvas", lambda db, cti_id, threshold: (True, last_login))
+        
+        def mock_filter_side_effect(*args, **kwargs):
+            mock_result = MagicMock()
+            mock_result.first.return_value = acc
+            return mock_result
+        
+        # Set up database operation mocks
+        mock_postgresql_db.query.return_value.filter.side_effect = mock_filter_side_effect
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.add.return_value = None
+        
+        # Make the API call
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        # Verify the response
+        assert res.status_code == 200
+        data = res.json()
+        assert data["students_marked_active"] == 1
+        assert data["students_marked_inactive"] == 0
+        
+        # Verify BOTH activity types are tracked in the response
+        assert data["details"][0]["attendance_activity"] == True
+        assert data["details"][0]["canvas_activity"] == True
+        assert data["details"][0]["last_canvas_access"] is not None
+        assert data["details"][0]["active"] == True
+        
+        # Verify the status changed to active in the database
+        assert acc.active == True
+    
+    
+    def test_student_active_with_attendance_only(self, client, monkeypatch, mock_postgresql_db):
+        """Test student marked active due to attendance only (no Canvas activity)."""
+        # Create a mock student
+        student = MagicMock()
+        student.cti_id = 2001
+        student.fullname = "Attendance Only Student"
+        student.active = True
+        
+        # Mock the database query
+        mock_query = MagicMock()
+        mock_query.join.return_value.filter.return_value.all.return_value = [student]
+        mock_postgresql_db.query.return_value = mock_query
+        
+        # Create mock Accelerate record starting as INACTIVE
+        acc = MagicMock()
+        acc.cti_id = 2001
+        acc.active = False
+        
+        # Mock attendance check to return True - student HAS attended sessions
+        monkeypatch.setattr(svc, "check_attendance", lambda db, cti_id, threshold: True)
+        
+        # Mock Canvas check to return False - NO Canvas activity
+        monkeypatch.setattr(svc, "check_canvas", lambda db, cti_id, threshold: (False, None))
+        
+        def mock_filter_side_effect(*args, **kwargs):
+            mock_result = MagicMock()
+            mock_result.first.return_value = acc
+            return mock_result
+        
+        mock_postgresql_db.query.return_value.filter.side_effect = mock_filter_side_effect
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.add.return_value = None
+        
+        # Make the API call
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        # Verify the response
+        assert res.status_code == 200
+        data = res.json()
+        assert data["students_marked_active"] == 1
+        
+        # Verify only attendance activity is true
+        assert data["details"][0]["attendance_activity"] == True
+        assert data["details"][0]["canvas_activity"] == False
+        assert data["details"][0]["last_canvas_access"] is None
+        assert data["details"][0]["active"] == True
+        
+        # Verify status changed to active
+        assert acc.active == True
+    
+    
+    def test_student_active_with_canvas_only(self, client, monkeypatch, mock_postgresql_db):
+        """Test student marked active due to Canvas activity only (no attendance)."""
+        # Create a mock student
+        student = MagicMock()
+        student.cti_id = 3001
+        student.fullname = "Canvas Only Student"
+        student.active = True
+        
+        # Mock the database query
+        mock_query = MagicMock()
+        mock_query.join.return_value.filter.return_value.all.return_value = [student]
+        mock_postgresql_db.query.return_value = mock_query
+        
+        # Create mock Accelerate record starting as INACTIVE
+        acc = MagicMock()
+        acc.cti_id = 3001
+        acc.active = False
+        
+        # Mock attendance check to return False - NO attendance
+        monkeypatch.setattr(svc, "check_attendance", lambda db, cti_id, threshold: False)
+        
+        # Mock Canvas check to return True with recent login
+        pacific_tz = pytz.timezone('America/Los_Angeles')
+        last_login = datetime.now(pacific_tz).replace(tzinfo=None) - timedelta(hours=6)
+        monkeypatch.setattr(svc, "check_canvas", lambda db, cti_id, threshold: (True, last_login))
+        
+        def mock_filter_side_effect(*args, **kwargs):
+            mock_result = MagicMock()
+            mock_result.first.return_value = acc
+            return mock_result
+        
+        mock_postgresql_db.query.return_value.filter.side_effect = mock_filter_side_effect
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.add.return_value = None
+        
+        # Make the API call
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        # Verify the response
+        assert res.status_code == 200
+        data = res.json()
+        assert data["students_marked_active"] == 1
+        assert data["students_marked_inactive"] == 0
+        
+        # Verify only Canvas activity is true
+        assert data["details"][0]["attendance_activity"] == False
+        assert data["details"][0]["canvas_activity"] == True
+        assert data["details"][0]["last_canvas_access"] is not None
+        assert data["details"][0]["active"] == True
+        
+        # Verify status changed to active
+        assert acc.active == True
+    
+    
+    def test_student_inactive_with_no_activity(self, client, monkeypatch, mock_postgresql_db):
+        """Test student marked inactive when they have NO attendance or Canvas activity."""
+        # Create a mock student
+        student = MagicMock()
+        student.cti_id = 4001
+        student.fullname = "Inactive Student"
+        student.active = True
+        
+        # Mock the database query
+        mock_query = MagicMock()
+        mock_query.join.return_value.filter.return_value.all.return_value = [student]
+        mock_postgresql_db.query.return_value = mock_query
+        
+        # Create mock Accelerate record starting as ACTIVE (will change to inactive)
+        acc = MagicMock()
+        acc.cti_id = 4001
+        acc.active = True
+        
+        # Mock attendance check to return False - NO attendance
+        monkeypatch.setattr(svc, "check_attendance", lambda db, cti_id, threshold: False)
+        
+        # Mock Canvas check to return False - NO Canvas activity
+        monkeypatch.setattr(svc, "check_canvas", lambda db, cti_id, threshold: (False, None))
+        
+        def mock_filter_side_effect(*args, **kwargs):
+            mock_result = MagicMock()
+            mock_result.first.return_value = acc
+            return mock_result
+        
+        mock_postgresql_db.query.return_value.filter.side_effect = mock_filter_side_effect
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.add.return_value = None
+        
+        # Make the API call
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        # Verify the response
+        assert res.status_code == 200
+        data = res.json()
+        assert data["students_marked_active"] == 0
+        assert data["students_marked_inactive"] == 1
+        
+        # Verify no activity detected
+        assert data["details"][0]["attendance_activity"] == False
+        assert data["details"][0]["canvas_activity"] == False
+        assert data["details"][0]["last_canvas_access"] is None
+        assert data["details"][0]["active"] == False
+        
+        # Verify status changed to inactive
+        assert acc.active == False
+    
+    
+    def test_no_active_students(self, client, mock_postgresql_db):
+        """Test case where no active students are found."""
+        mock_query = MagicMock()
+        mock_query.join.return_value.filter.return_value.all.return_value = []
+        mock_postgresql_db.query.return_value = mock_query
+        mock_postgresql_db.commit.return_value = None
+        
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        assert res.status_code == 200
+        data = res.json()
+        assert data["status"] == 200
+        assert data["students_processed"] == 0
+        assert data["students_marked_active"] == 0
+        assert data["students_marked_inactive"] == 0
+        assert len(data["details"]) == 0
+        assert len(data["errors"]) == 0
+    
+    
+    def test_canvas_api_error_handled_gracefully(self, client, monkeypatch, mock_postgresql_db):
+        """Test that Canvas API errors are handled per-student without crashing."""
+        student_1 = MagicMock()
+        student_1.cti_id = 3001
+        student_1.fullname = "Error Student"
+        student_1.active = True
+        
+        student_2 = MagicMock()
+        student_2.cti_id = 3002
+        student_2.fullname = "Good Student"
+        student_2.active = True
+        
+        mock_query = MagicMock()
+        mock_query.join.return_value.filter.return_value.all.return_value = [student_1, student_2]
+        mock_postgresql_db.query.return_value = mock_query
+        
+        acc_1 = MagicMock()
+        acc_1.cti_id = 3001
+        acc_1.active = True
+        
+        acc_2 = MagicMock()
+        acc_2.cti_id = 3002
+        acc_2.active = False
+        
+        monkeypatch.setattr(svc, "check_attendance", lambda db, cti_id, threshold: True)
+        
+        def mock_check_canvas(db, cti_id, threshold):
+            if cti_id == 3001:
+                raise ValueError("Canvas API authentication failed")
+            return False, None
+        
+        monkeypatch.setattr(svc, "check_canvas", mock_check_canvas)
+        
+        def mock_filter_side_effect(*args, **kwargs):
+            mock_result = MagicMock()
+            filter_expr = args[0] if args else None
+            if hasattr(filter_expr, 'left') and hasattr(filter_expr.left, 'name'):
+                if filter_expr.left.name == 'cti_id':
+                    cti_id = filter_expr.right.value
+                    mock_result.first.return_value = acc_1 if cti_id == 3001 else acc_2
+            return mock_result
+        
+        mock_postgresql_db.query.return_value.filter.side_effect = mock_filter_side_effect
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.rollback.return_value = None
+        mock_postgresql_db.add.return_value = None
+        
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        assert res.status_code == 200
+        data = res.json()
+        assert data["students_processed"] == 2
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["cti_id"] == 3001
+        assert "Canvas API" in data["errors"][0]["error"]
+        assert mock_postgresql_db.rollback.call_count == 1
+        assert mock_postgresql_db.commit.call_count == 1
+    
+    
+    def test_creates_accelerate_course_progress_record(self, client, monkeypatch, mock_postgresql_db):
+        """Test that accelerate_course_progress records are created if they don't exist."""
+        student = MagicMock()
+        student.cti_id = 5001
+        student.fullname = "New Progress"
+        student.active = True
+        
+        acc = MagicMock()
+        acc.cti_id = 5001
+        acc.active = False
+        
+        monkeypatch.setattr(svc, "check_attendance", lambda db, cti_id, threshold: True)
+        
+        pacific_tz = pytz.timezone('America/Los_Angeles')
+        last_login = datetime.now(pacific_tz).replace(tzinfo=None)
+        monkeypatch.setattr(svc, "check_canvas", lambda db, cti_id, threshold: (True, last_login))
+        
+        added_records = []
+        
+        def mock_add(record):
+            added_records.append(record)
+        
+        def mock_query_side_effect(model):
+            mock_result = MagicMock()
+            mock_result.join.return_value.filter.return_value.all.return_value = [student]
+            mock_result.filter.return_value.first.return_value = acc if model.__name__ == 'Accelerate' else None
+            return mock_result
+        
+        mock_postgresql_db.query.side_effect = mock_query_side_effect
+        mock_postgresql_db.add.side_effect = mock_add
+        mock_postgresql_db.commit.return_value = None
+        
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        assert res.status_code == 200
+        assert len(added_records) == 1
+        assert isinstance(added_records[0], AccelerateCourseProgress)
+        assert added_records[0].cti_id == 5001
+        assert added_records[0].last_canvas_access == last_login
+
+
+    def test_updates_existing_accelerate_course_progress_record(self, client, monkeypatch, mock_postgresql_db):
+        """Test that existing accelerate_course_progress records are updated with new last_canvas_access."""
+        student = MagicMock()
+        student.cti_id = 6001
+        student.fullname = "Existing Progress"
+        student.active = True
+        
+        acc = MagicMock()
+        acc.cti_id = 6001
+        acc.active = False
+        
+        pacific_tz = pytz.timezone('America/Los_Angeles')
+        old_login = datetime.now(pacific_tz).replace(tzinfo=None) - timedelta(days=10)
+        existing_progress = MagicMock()
+        existing_progress.cti_id = 6001
+        existing_progress.last_canvas_access = old_login
+        
+        monkeypatch.setattr(svc, "check_attendance", lambda db, cti_id, threshold: True)
+        
+        new_login = datetime.now(pacific_tz).replace(tzinfo=None) - timedelta(hours=2)
+        monkeypatch.setattr(svc, "check_canvas", lambda db, cti_id, threshold: (True, new_login))
+        
+        added_records = []
+        
+        def mock_add(record):
+            added_records.append(record)
+        
+        def mock_query_side_effect(model):
+            mock_result = MagicMock()
+            mock_result.join.return_value.filter.return_value.all.return_value = [student]
+            if model.__name__ == 'Accelerate':
+                mock_result.filter.return_value.first.return_value = acc
+            elif model.__name__ == 'AccelerateCourseProgress':
+                mock_result.filter.return_value.first.return_value = existing_progress
+            else:
+                mock_result.filter.return_value.first.return_value = None
+            return mock_result
+        
+        mock_postgresql_db.query.side_effect = mock_query_side_effect
+        mock_postgresql_db.add.side_effect = mock_add
+        mock_postgresql_db.commit.return_value = None
+        
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        assert res.status_code == 200
+        assert len([r for r in added_records if isinstance(r, AccelerateCourseProgress)]) == 0
+        assert existing_progress.last_canvas_access == new_login
+        assert existing_progress.last_canvas_access != old_login
+
+
+    def test_no_canvas_id_skips_canvas_check(self, client, monkeypatch, mock_postgresql_db):
+        """Test that students without a canvas_id record don't get Canvas activity checked."""
+        student = MagicMock()
+        student.cti_id = 7001
+        student.fullname = "No Canvas"
+        student.active = True
+        
+        acc = MagicMock()
+        acc.cti_id = 7001
+        acc.active = True
+        
+        monkeypatch.setattr(svc, "check_attendance", lambda db, cti_id, threshold: True)
+        
+        def mock_query_side_effect(model):
+            mock_result = MagicMock()
+            mock_result.join.return_value.filter.return_value.all.return_value = [student]
+            if model.__name__ == 'CanvasID':
+                mock_result.filter.return_value.first.return_value = None
+            elif model.__name__ == 'Accelerate':
+                mock_result.filter.return_value.first.return_value = acc
+            else:
+                mock_result.filter.return_value.first.return_value = None
+            return mock_result
+        
+        mock_postgresql_db.query.side_effect = mock_query_side_effect
+        mock_postgresql_db.commit.return_value = None
+        mock_postgresql_db.add.return_value = None
+        
+        res = client.post("/api/students/accelerate/check-activity")
+        
+        assert res.status_code == 200
+        data = res.json()
+        assert data["students_marked_active"] == 1
+        assert data["details"][0]["canvas_activity"] == False
+        assert data["details"][0]["last_canvas_access"] is None
+        assert acc.active == True
+
+


### PR DESCRIPTION
## Check Activity Endpoint

This PR implements an activity checking endpoint for Accelerate students that monitors both **attendance** and **Canvas engagement** to determine student activity status. It automatically creates `accelerate_course_progress` records for students who don't have one, or updates existing records with the latest Canvas access timestamp.

### Issues Fixed
* https://github.com/NickGuerrero/cti-sys/issues/66

### How It Works

The endpoint checks students who are active in the main student roster (`students.active = True`) and enrolled in Accelerate, then updates their `accelerate.active` status based on recent activity.

- Recent attendance at Accelerate sessions *(configurable threshold in weeks)*
- Recent Canvas login access *(configurable threshold in weeks)*

**Activity Logic**

Students are marked as **active** in `accelerate.active` if they have **either**:
- Attended an Accelerate session within the threshold period, **OR**
- Accessed Canvas within the threshold period


### Database Changes

**Migration:** Added `last_canvas_access` field to `accelerate_course_progress` table:

**Apply Migration:**

1. Make sure DB URL has `postgresql+psycopg`:
```bash
   export DEV_DATABASE_URL="postgresql+psycopg://.../devdb"
```

2. Run the migration:
```bash
   alembic -x environment=development upgrade head
```

### Tests
`TestCheckAccelerateActivity` pytest includes 9 total tests:

- All activity combinations (both, attendance only, Canvas only, none)
- Edge cases (no students, missing Canvas ID)
- Error handling (Canvas API failures, graceful per-student rollback)
- Database operations (create/update accelerate_course_progress records)


**To run tests locally:**
```
pytest -v -k "TestCheckAccelerateActivity"
```

<img width="1332" height="415" alt="Screenshot 2025-12-11 at 4 39 23 PM" src="https://github.com/user-attachments/assets/8628a730-0100-4434-ab70-f408f35532b9" />


**On Github Actions:**
```
pytest -v -m "not integration"
```
<img width="1225" height="376" alt="Screenshot 2025-12-11 at 4 41 42 PM" src="https://github.com/user-attachments/assets/89170247-46cd-47e3-acde-a450ed753d5f" />

### Not Implemented (Future Enhancement)

**Program Breaks / Skip Weeks:** This implementation does not currently account for program breaks where students aren't required to attend sessions, as initially requested in the issue. We will revisit this enhancement at a later time.



### Checklist
- [x] I've reviewed the contribution guide
- [x] I've confirmed the changes work on my machine
- [x] This pull request is ready for review