### PR TITLE
Removes direct env access from env.py and keeps runtime DB selection …

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,9 +1,7 @@
 from logging.config import fileConfig
-import os
-
 from sqlalchemy import engine_from_config, create_engine
 from sqlalchemy import pool
-
+from src.config import settings
 from alembic import context
 
 # this is the Alembic Config object, which provides
@@ -22,9 +20,9 @@ target_metadata = models.Base.metadata
 
 # map Alembic environment names to DB URLs
 DB_URLS = {
-    "development": os.getenv("DEV_DATABASE_URL"),
-    "production": os.getenv("PROD_DATABASE_URL"),
-    "custom": os.getenv("CUSTOM_DATABASE_URL"),
+    "development": settings.dev_database_url,
+    "production": settings.prod_database_url,
+    "custom": settings.custom_database_url,
 }
 
 def get_url() -> str:
@@ -39,9 +37,8 @@ def get_url() -> str:
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
-from os import environ as env
 def env_url():
-    return env.get("CTI_POSTGRES_URL")
+    return settings.cti_postgres_url
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode.

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,11 @@ class Settings(BaseSettings):
     cti_mongo_url: Optional[str] = Field(validation_alias="CTI_MONGO_URL", default=None)
     cti_postgres_url: Optional[str] = Field(validation_alias="CTI_POSTGRES_URL", default=None)
 
+    # Alembic / Migration Database URLs
+    dev_database_url: Optional[str] = Field(validation_alias="DEV_DATABASE_URL", default=None)
+    prod_database_url: Optional[str] = Field(validation_alias="PROD_DATABASE_URL", default=None)
+    custom_database_url: Optional[str] = Field(validation_alias="CUSTOM_DATABASE_URL", default=None)
+
     # Canvas Variables, only required for Canvas specific-operations
     # NOTE: SIS ID's are needed for SIS operations, must be manually defined ahead of time
     # TODO: Rename CTI_ACCESS_TOKEN to CTI_CANVAS_TOKEN, improve clarity on token purpose and differentiate from server token


### PR DESCRIPTION
Pull Request Name
Centralize migration database environment variables in settings

Description
This PR centralizes all database-related environment variables used for Alembic migrations into config.py and updates env.py to reference them via settings.

Direct calls to os.getenv() have been removed from env.py, while preserving the existing runtime database selection logic for migrations. This aligns migration configuration with the rest of the application and avoids special-case environment access.

Issues Fixed
Fixes: #49 

Tests
Integration tests were not run because they require sensitive environment variables that are not available locally.

All non-integration tests pass locally. Migration configuration was verified by ensuring Alembic correctly resolves the database URL via centralized settings without direct environment access.

Checklist
[x] I've reviewed the contribution guide
[x] I've confirmed the changes work on my machine
[x] This pull request is ready for review
