### PR TITLE
Accelerate Attendance Bug

### DIFF
--- a/src/students/accelerate/process_attendance/router.py
+++ b/src/students/accelerate/process_attendance/router.py
@@ -20,7 +20,6 @@ def process_accelerate_attendance(db: Session = Depends(make_session)) -> Dict[s
     """
     # return process_accelerate_metrics(db)
     try:
-        print("Test starting")
         return process_accelerate_metrics(db)
     except Exception as e:
         handle_db_exceptions(db, e)

--- a/src/students/accelerate/process_attendance/router.py
+++ b/src/students/accelerate/process_attendance/router.py
@@ -20,6 +20,7 @@ def process_accelerate_attendance(db: Session = Depends(make_session)) -> Dict[s
     """
     # return process_accelerate_metrics(db)
     try:
+        print("Test starting")
         return process_accelerate_metrics(db)
     except Exception as e:
         handle_db_exceptions(db, e)

--- a/src/students/accelerate/process_attendance/service.py
+++ b/src/students/accelerate/process_attendance/service.py
@@ -24,12 +24,10 @@ def process_accelerate_metrics(db: Session) -> Dict[str, int]:
     acc_rows = load_active_accelerate_records(db)
     attend_rows = load_attendance_rows(db, [a.cti_id for a in acc_rows])
 
-    # per_student = group_attendance_by_student(attend_rows)
-    # updated = update_accelerate_records(db, acc_rows, per_student)
-    updated = 1
-    print(attend_rows)
+    per_student = group_attendance_by_student(attend_rows)
+    updated = update_accelerate_records(db, acc_rows, per_student)
 
-    # db.commit()
+    db.commit()
     return {"status": 200, "records_updated": updated}
 
 

--- a/src/students/accelerate/process_attendance/service.py
+++ b/src/students/accelerate/process_attendance/service.py
@@ -21,8 +21,6 @@ def process_accelerate_metrics(db: Session) -> Dict[str, int]:
 
     Always returns { status = 200, records_updated = int}.
     """
-    print("0. Works")
-
     acc_rows = load_active_accelerate_records(db)
     print("1. Works")
     attend_rows = load_attendance_rows(db, [a.cti_id for a in acc_rows])
@@ -77,6 +75,7 @@ def load_attendance_rows(
         )
         .all()
     )
+    print(rows)
     # Convert datetime to date for easier week bucketing
     return [(cid, sess.date(), score) for cid, sess, score in rows]
 

--- a/src/students/accelerate/process_attendance/service.py
+++ b/src/students/accelerate/process_attendance/service.py
@@ -21,6 +21,8 @@ def process_accelerate_metrics(db: Session) -> Dict[str, int]:
 
     Always returns { status = 200, records_updated = int}.
     """
+    print("0. Works")
+
     acc_rows = load_active_accelerate_records(db)
     print("1. Works")
     attend_rows = load_attendance_rows(db, [a.cti_id for a in acc_rows])

--- a/src/students/accelerate/process_attendance/service.py
+++ b/src/students/accelerate/process_attendance/service.py
@@ -22,12 +22,17 @@ def process_accelerate_metrics(db: Session) -> Dict[str, int]:
     Always returns { status = 200, records_updated = int}.
     """
     acc_rows = load_active_accelerate_records(db)
+    print("1. Works")
     attend_rows = load_attendance_rows(db, [a.cti_id for a in acc_rows])
+    print("2. Works")
 
     per_student = group_attendance_by_student(attend_rows)
+    print("3. Works")
     updated = update_accelerate_records(db, acc_rows, per_student)
+    print("4. Works")
 
     db.commit()
+    print("5. Works")
     return {"status": 200, "records_updated": updated}
 
 

--- a/src/students/accelerate/process_attendance/service.py
+++ b/src/students/accelerate/process_attendance/service.py
@@ -26,7 +26,7 @@ def process_accelerate_metrics(db: Session) -> Dict[str, int]:
 
     # per_student = group_attendance_by_student(attend_rows)
     # updated = update_accelerate_records(db, acc_rows, per_student)
-    updated = "TEST"
+    updated = 1
     print(attend_rows)
 
     # db.commit()

--- a/src/students/accelerate/process_attendance/service.py
+++ b/src/students/accelerate/process_attendance/service.py
@@ -22,17 +22,14 @@ def process_accelerate_metrics(db: Session) -> Dict[str, int]:
     Always returns { status = 200, records_updated = int}.
     """
     acc_rows = load_active_accelerate_records(db)
-    print("1. Works")
     attend_rows = load_attendance_rows(db, [a.cti_id for a in acc_rows])
-    print("2. Works")
 
-    per_student = group_attendance_by_student(attend_rows)
-    print("3. Works")
-    updated = update_accelerate_records(db, acc_rows, per_student)
-    print("4. Works")
+    # per_student = group_attendance_by_student(attend_rows)
+    # updated = update_accelerate_records(db, acc_rows, per_student)
+    updated = "TEST"
+    print(attend_rows)
 
-    db.commit()
-    print("5. Works")
+    # db.commit()
     return {"status": 200, "records_updated": updated}
 
 
@@ -69,13 +66,13 @@ def load_attendance_rows(
             select(
                 StudentAttendance.cti_id,
                 Attendance.session_start,
+                StudentAttendance.peardeck_score,
             )
             .join(Attendance, Attendance.session_id == StudentAttendance.session_id)
             .where(StudentAttendance.cti_id.in_(cti_ids))
         )
         .all()
     )
-    print(rows)
     # Convert datetime to date for easier week bucketing
     return [(cid, sess.date(), score) for cid, sess, score in rows]
 


### PR DESCRIPTION
## Student Accelerate Attendance Bug

When attempting to process student attendance on PearDeck into participation metrics, we faced an error detailing: "Unexpected error: not enough values to unpack (expected 3, got 2)". This means that somewhere in our algorithm, we were trying to extract three values when we only returned two. 

### Issues Fixed
* https://github.com/NickGuerrero/cti-sys/issues/71

The issue was that we were trying to return the score for each row, but the score wasn't being called in the SQL script. After including the "peardeck_score" column, the endpoint works perfectly fine!

<img width="1417" height="575" alt="Screenshot 2026-01-13 at 4 42 42 PM" src="https://github.com/user-attachments/assets/cc0a9b9c-0128-413e-b4ad-136f8857c215" />

### Checklist
- [x] I've reviewed the contribution guide
- [x] I've confirmed the changes work on my machine
- [x] This pull request is ready for review